### PR TITLE
Add basic telemetry via VS Code telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.1.0 - 6 December 2021
 
 ### Added
-- Telemetry for activating, running a job, and no jobs. [#50](https://github.com/getlocalci/local-ci/pull/50/)
+- Telemetry for activating, running a job, and no jobs, opt out with `"telemetry.enableTelemetry": false`. [#50](https://github.com/getlocalci/local-ci/pull/50/)
 
 ## 1.0.2 - 5 December 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.1.0 - 6 December 2021
+
+### Added
+- Telemetry for activating, running a job, and no jobs. [#50](https://github.com/getlocalci/local-ci/pull/50/)
+
 ## 1.0.2 - 5 December 2021
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can opt out of telemetry by adding this to your VS Code `settings.json`:
 
 `"telemetry.enableTelemetry": false`
 
-If you haven't opted out, this will send the following data via [VS Code telemetry](https://code.visualstudio.com/docs/getstarted/telemetry):
+If you haven't opted out, this will send the following events via [VS Code telemetry](https://code.visualstudio.com/docs/getstarted/telemetry):
 
 * This extension is activated
 * There are no jobs found, like if there's no `.circleci/config.yml` file

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ If there's more than one `.circleci/config.yml` file, click the gear icon to sel
 
 ## Privacy
 
+You can opt out of telemetry by adding this to your VS Code `settings.json`:
+
+`"telemetry.enableTelemetry": false`
+
+If you haven't opted out, this will send the following data via [VS Code telemetry](https://code.visualstudio.com/docs/getstarted/telemetry):
+
+* This extension is activated
+* There are no jobs found, like with `.circleci/config.yml` file
+* A CircleCI® job is run (but no data about the job, not even the name)
+
 If you haven't entered a license key, like during the free preview, this extension has no interaction with Local CI's site.
 
 It does interact with CircleCI® and Docker to process and run the jobs.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ You can opt out of telemetry by adding this to your VS Code `settings.json`:
 If you haven't opted out, this will send the following data via [VS Code telemetry](https://code.visualstudio.com/docs/getstarted/telemetry):
 
 * This extension is activated
-* There are no jobs found, like with `.circleci/config.yml` file
-* A CircleCI® job is run (but no data about the job, not even the name)
+* There are no jobs found, like if there's no `.circleci/config.yml` file
+* A CircleCI® job is run (but it sends no data about the job, not even the name)
 
 If you haven't entered a license key, like during the free preview, this extension has no interaction with Local CI's site.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       ],
       "dependencies": {
         "axios": "^0.21.4",
-        "js-md5": "0.7.3"
+        "js-md5": "0.7.3",
+        "vscode-extension-telemetry": "^0.4.3"
       },
       "devDependencies": {
         "@cloudflare/binary-install": "^0.2.0",
@@ -4883,6 +4884,14 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/vscode-extension-telemetry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.3.tgz",
+      "integrity": "sha512-opiIFOaAwyfACYMXByDqFMAlJ2iFMJR65/vIogJ960aLZWp9zaMdwY9CsY02EOYjHxPpjI7QeOQM3sYCb3xtJg==",
+      "engines": {
+        "vscode": "^1.60.0"
+      }
+    },
     "node_modules/vscode-test": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
@@ -9166,6 +9175,11 @@
           "dev": true
         }
       }
+    },
+    "vscode-extension-telemetry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.3.tgz",
+      "integrity": "sha512-opiIFOaAwyfACYMXByDqFMAlJ2iFMJR65/vIogJ960aLZWp9zaMdwY9CsY02EOYjHxPpjI7QeOQM3sYCb3xtJg=="
     },
     "vscode-test": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "local-ci",
   "displayName": "Local CI",
   "description": "Debug CircleCI® workflows locally, with Bash access during and after. Free preview, then paid.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "publisher": "LocalCI",
   "contributors": [
     "Ryan Kienstra"
@@ -293,6 +293,7 @@
   },
   "dependencies": {
     "axios": "^0.21.4",
-    "js-md5": "0.7.3"
+    "js-md5": "0.7.3",
+    "vscode-extension-telemetry": "^0.4.3"
   }
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,6 +4,8 @@ export const LICENSE_ERROR = 'localCiLicenseKeyError';
 export const GET_LICENSE_COMMAND = 'local-ci.license.get';
 export const ENTER_LICENSE_COMMAND = 'local-ci.license.enter';
 export const EXIT_JOB_COMMAND = 'local-ci.job.exit';
+export const EXTENSION_ID = 'LocalCI.local-ci';
+export const EXTENSION_VERSION = '1.1.0';
 
 // @todo: Look at an alternative, as docker inspect hangs sometimes: https://github.com/docker/for-linux/issues/397
 export const GET_CONTAINER_FUNCTION = `get_container() {
@@ -55,3 +57,4 @@ export const SCHEDULE_INTERVIEW_URL =
 export const SUPPRESS_UNCOMMITTED_FILE_WARNING =
   'local-ci.suppress-warning.uncommitted';
 export const SURVEY_URL = 'https://www.surveymonkey.com/r/localci';
+export const TELEMETRY_KEY = '<your key>';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,11 +1,11 @@
+export const EXTENSION_VERSION = '1.1.0';
+export const EXTENSION_ID = 'LocalCI.local-ci';
 export const COMMITTED_IMAGE_NAMESPACE = 'local-ci';
 export const SELECTED_CONFIG_PATH = 'local-ci.config.path';
 export const LICENSE_ERROR = 'localCiLicenseKeyError';
 export const GET_LICENSE_COMMAND = 'local-ci.license.get';
 export const ENTER_LICENSE_COMMAND = 'local-ci.license.enter';
 export const EXIT_JOB_COMMAND = 'local-ci.job.exit';
-export const EXTENSION_ID = 'LocalCI.local-ci';
-export const EXTENSION_VERSION = '1.1.0';
 
 // @todo: Look at an alternative, as docker inspect hangs sometimes: https://github.com/docker/for-linux/issues/397
 export const GET_CONTAINER_FUNCTION = `get_container() {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -57,4 +57,4 @@ export const SCHEDULE_INTERVIEW_URL =
 export const SUPPRESS_UNCOMMITTED_FILE_WARNING =
   'local-ci.suppress-warning.uncommitted';
 export const SURVEY_URL = 'https://www.surveymonkey.com/r/localci';
-export const TELEMETRY_KEY = '<your key>';
+export const TELEMETRY_KEY = '90189d4e-b560-4a92-aa2c-5a9df190b66a'; // Microsoft.AppInsights Instrumentation Key.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,12 +8,15 @@ import {
   COMMITTED_IMAGE_NAMESPACE,
   ENTER_LICENSE_COMMAND,
   EXIT_JOB_COMMAND,
+  EXTENSION_ID,
+  EXTENSION_VERSION,
   GET_LICENSE_COMMAND,
   GET_LICENSE_KEY_URL,
   HELP_URL,
   JOB_TREE_VIEW_ID,
   RUN_JOB_COMMAND,
   SELECTED_CONFIG_PATH,
+  TELEMETRY_KEY,
   TRIAL_STARTED_TIMESTAMP,
 } from './constants';
 import cleanUpCommittedImages from './utils/cleanUpCommittedImages';
@@ -31,16 +34,17 @@ import runJob from './utils/runJob';
 import showLicenseInput from './utils/showLicenseInput';
 import writeProcessFile from './utils/writeProcessFile';
 
-const extensionId = 'LocalCI.local-ci';
-const extensionVersion = '1.1.0';
-const key = '<your key>';
-
 export function activate(context: vscode.ExtensionContext): void {
   if (!context.globalState.get(TRIAL_STARTED_TIMESTAMP)) {
     context.globalState.update(TRIAL_STARTED_TIMESTAMP, new Date().getTime());
   }
   const jobProvider = new JobProvider(context);
-  const reporter = new TelemetryReporter(extensionId, extensionVersion, key);
+  const reporter = new TelemetryReporter(
+    EXTENSION_ID,
+    EXTENSION_VERSION,
+    TELEMETRY_KEY
+  );
+  reporter.sendTelemetryEvent('activate');
   const reportRunJob = () => reporter.sendTelemetryEvent('runJob');
 
   vscode.window.registerTreeDataProvider(JOB_TREE_VIEW_ID, jobProvider);

--- a/src/utils/getJobs.ts
+++ b/src/utils/getJobs.ts
@@ -1,10 +1,12 @@
 import * as vscode from 'vscode';
+import TelemetryReporter from 'vscode-extension-telemetry';
 import Job from '../classes/Job';
 import Warning from '../classes/Warning';
 import Command from '../classes/Command';
 import getAllConfigFilePaths from './getAllConfigFilePaths';
 import getConfig from './getConfig';
 import isWindows from './isWindows';
+import { EXTENSION_ID, EXTENSION_VERSION, TELEMETRY_KEY } from '../constants';
 
 export default async function getJobs(
   context: vscode.ExtensionContext,
@@ -37,6 +39,14 @@ export default async function getJobs(
           []
         )
       : [];
+
+  if (!jobs.length) {
+    new TelemetryReporter(
+      EXTENSION_ID,
+      EXTENSION_VERSION,
+      TELEMETRY_KEY
+    ).sendTelemetryEvent('noJobs');
+  }
 
   return jobs.length
     ? jobs.map((jobName) => new Job(jobName, jobName === runningJob))

--- a/src/utils/runJob.ts
+++ b/src/utils/runJob.ts
@@ -26,7 +26,8 @@ import uncommittedWarning from './uncommittedWarning';
 
 export default async function runJob(
   context: vscode.ExtensionContext,
-  jobName: string
+  jobName: string,
+  reportRunJob: () => void
 ): Promise<void> {
   const configFilePath = await getConfigFilePath(context);
   const repoPath = path.dirname(path.dirname(configFilePath));
@@ -41,6 +42,7 @@ export default async function runJob(
     cwd: repoPath,
   });
   terminal.show();
+  reportRunJob();
 
   const processFilePath = getProcessFilePath(configFilePath);
   const parsedProcessFile = getConfigFromPath(processFilePath);


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* This respects the VS Code telemetry settings: `"telemetry.enableTelemetry": false`
* I feel bad adding this now that I have 153 users
* But many of those probably won't have access to the extension at all, as the free preview only lasts 2 days
* Without getting feedback, this whole project might be in jeopardy
