### PR TITLE
Fix `cannot stat` error in  `tmp/`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "local-ci",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "local-ci",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "os": [

--- a/src/test/suite/utils/getAttachWorkspaceCommand.test.ts
+++ b/src/test/suite/utils/getAttachWorkspaceCommand.test.ts
@@ -9,7 +9,7 @@ suite('getAttachWorkspaceCommand', () => {
   test('With attach_workspace', () => {
     assert.strictEqual(
       getAttachWorkspaceCommand({ attach_workspace: { at: '/foo/baz' } }), // eslint-disable-line @typescript-eslint/naming-convention
-      'if [ -d ! /tmp/local-ci ] && [ -z "$(ls -A /tmp/local-ci)" ]; then cp -rn /tmp/local-ci/* /foo/baz || cp -ru /tmp/local-ci/* /foo/baz; fi'
+      'if [ -d /tmp/local-ci ] && [ ! -z "$(ls -A /tmp/local-ci)" ]; then cp -rn /tmp/local-ci/* /foo/baz || cp -ru /tmp/local-ci/* /foo/baz; fi'
     );
   });
 });

--- a/src/test/suite/utils/getAttachWorkspaceCommand.test.ts
+++ b/src/test/suite/utils/getAttachWorkspaceCommand.test.ts
@@ -9,7 +9,7 @@ suite('getAttachWorkspaceCommand', () => {
   test('With attach_workspace', () => {
     assert.strictEqual(
       getAttachWorkspaceCommand({ attach_workspace: { at: '/foo/baz' } }), // eslint-disable-line @typescript-eslint/naming-convention
-      'if [ -d /tmp/local-ci ] && [ ! -z "$(ls -A /tmp/local-ci)" ]; then cp -rn /tmp/local-ci/* /foo/baz || cp -ru /tmp/local-ci/* /foo/baz; fi'
+      'if [ -d /tmp/local-ci ] && [ "$(ls -A /tmp/local-ci)" ]; then cp -rn /tmp/local-ci/* /foo/baz || cp -ru /tmp/local-ci/* /foo/baz; fi'
     );
   });
 });

--- a/src/test/suite/utils/getAttachWorkspaceCommand.test.ts
+++ b/src/test/suite/utils/getAttachWorkspaceCommand.test.ts
@@ -9,7 +9,7 @@ suite('getAttachWorkspaceCommand', () => {
   test('With attach_workspace', () => {
     assert.strictEqual(
       getAttachWorkspaceCommand({ attach_workspace: { at: '/foo/baz' } }), // eslint-disable-line @typescript-eslint/naming-convention
-      'cp -rn /tmp/local-ci/* /foo/baz || cp -ru /tmp/local-ci/* /foo/baz'
+      'if [ -d ! /tmp/local-ci && -z "$(ls -A /tmp/local-ci)" ]; then cp -rn /tmp/local-ci/* /foo/baz || cp -ru /tmp/local-ci/* /foo/baz; fi'
     );
   });
 });

--- a/src/test/suite/utils/getAttachWorkspaceCommand.test.ts
+++ b/src/test/suite/utils/getAttachWorkspaceCommand.test.ts
@@ -9,7 +9,7 @@ suite('getAttachWorkspaceCommand', () => {
   test('With attach_workspace', () => {
     assert.strictEqual(
       getAttachWorkspaceCommand({ attach_workspace: { at: '/foo/baz' } }), // eslint-disable-line @typescript-eslint/naming-convention
-      'if [ -d ! /tmp/local-ci && -z "$(ls -A /tmp/local-ci)" ]; then cp -rn /tmp/local-ci/* /foo/baz || cp -ru /tmp/local-ci/* /foo/baz; fi'
+      'if [ -d ! /tmp/local-ci ] && [ -z "$(ls -A /tmp/local-ci)" ]; then cp -rn /tmp/local-ci/* /foo/baz || cp -ru /tmp/local-ci/* /foo/baz; fi'
     );
   });
 });

--- a/src/utils/getAttachWorkspaceCommand.ts
+++ b/src/utils/getAttachWorkspaceCommand.ts
@@ -9,5 +9,6 @@ export default function getAttachWorkspaceCommand(step: Step): string {
   const attachFrom = path.join(CONTAINER_STORAGE_DIRECTORY, '*');
 
   // BusyBox doesn't have the -n option.
-  return `if [ -d ${CONTAINER_STORAGE_DIRECTORY} ]; then cp -rn ${attachFrom} ${step?.attach_workspace?.at} || cp -ru ${attachFrom} ${step?.attach_workspace?.at}; fi`;
+  // Check if the directory is empty before
+  return `if [[ -d ${CONTAINER_STORAGE_DIRECTORY} && ! -z "$(ls -A ${CONTAINER_STORAGE_DIRECTORY})" ]]; then cp -rn ${attachFrom} ${step?.attach_workspace?.at} || cp -ru ${attachFrom} ${step?.attach_workspace?.at}; fi`;
 }

--- a/src/utils/getAttachWorkspaceCommand.ts
+++ b/src/utils/getAttachWorkspaceCommand.ts
@@ -9,5 +9,5 @@ export default function getAttachWorkspaceCommand(step: Step): string {
   const attachFrom = path.join(CONTAINER_STORAGE_DIRECTORY, '*');
 
   // BusyBox doesn't have the -n option.
-  return `if [ -d ${attachFrom} ]; then cp -rn ${attachFrom} ${step?.attach_workspace?.at} || cp -ru ${attachFrom} ${step?.attach_workspace?.at}; fi`;
+  return `if [ -d ${CONTAINER_STORAGE_DIRECTORY} ]; then cp -rn ${attachFrom} ${step?.attach_workspace?.at} || cp -ru ${attachFrom} ${step?.attach_workspace?.at}; fi`;
 }

--- a/src/utils/getAttachWorkspaceCommand.ts
+++ b/src/utils/getAttachWorkspaceCommand.ts
@@ -10,5 +10,5 @@ export default function getAttachWorkspaceCommand(step: Step): string {
 
   // BusyBox doesn't have the -n option.
   // Check if the directory is empty before
-  return `if [[ -d ${CONTAINER_STORAGE_DIRECTORY} && ! -z "$(ls -A ${CONTAINER_STORAGE_DIRECTORY})" ]]; then cp -rn ${attachFrom} ${step?.attach_workspace?.at} || cp -ru ${attachFrom} ${step?.attach_workspace?.at}; fi`;
+  return `if [ -d ${CONTAINER_STORAGE_DIRECTORY} ] && [ ! -z "$(ls -A ${CONTAINER_STORAGE_DIRECTORY})" ]; then cp -rn ${attachFrom} ${step?.attach_workspace?.at} || cp -ru ${attachFrom} ${step?.attach_workspace?.at}; fi`;
 }

--- a/src/utils/getAttachWorkspaceCommand.ts
+++ b/src/utils/getAttachWorkspaceCommand.ts
@@ -9,6 +9,6 @@ export default function getAttachWorkspaceCommand(step: Step): string {
   const attachFrom = path.join(CONTAINER_STORAGE_DIRECTORY, '*');
 
   // BusyBox doesn't have the -n option.
-  // Check if the directory is empty before
-  return `if [ -d ${CONTAINER_STORAGE_DIRECTORY} ] && [ ! -z "$(ls -A ${CONTAINER_STORAGE_DIRECTORY})" ]; then cp -rn ${attachFrom} ${step?.attach_workspace?.at} || cp -ru ${attachFrom} ${step?.attach_workspace?.at}; fi`;
+  // Check if the directory is empty before copying it.
+  return `if [ -d ${CONTAINER_STORAGE_DIRECTORY} ] && [ "$(ls -A ${CONTAINER_STORAGE_DIRECTORY})" ]; then cp -rn ${attachFrom} ${step?.attach_workspace?.at} || cp -ru ${attachFrom} ${step?.attach_workspace?.at}; fi`;
 }

--- a/src/utils/getAttachWorkspaceCommand.ts
+++ b/src/utils/getAttachWorkspaceCommand.ts
@@ -9,5 +9,5 @@ export default function getAttachWorkspaceCommand(step: Step): string {
   const attachFrom = path.join(CONTAINER_STORAGE_DIRECTORY, '*');
 
   // BusyBox doesn't have the -n option.
-  return `cp -rn ${attachFrom} ${step?.attach_workspace?.at} || cp -ru ${attachFrom} ${step?.attach_workspace?.at}`;
+  return `if [ -d ${attachFrom} ]; then cp -rn ${attachFrom} ${step?.attach_workspace?.at} || cp -ru ${attachFrom} ${step?.attach_workspace?.at}; fi`;
 }


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Before, there was an error in 'Attach workspace': `cp: cannot stat '/tmp/local-ci/*' No such file or directory`

#### Testing instructions
* Run a job with an `Attach workspace` step
