### PR TITLE
Allow entering an API token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.3.1 - 16 December 2021
+
+### Added
+- Allow entering a CircleCI® API token. [#57](https://github.com/getlocalci/local-ci/pull/57)
+
 ## 1.3.0 - 15 December 2021
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Get Bash access to the running job by clicking 'Local CI debugging':
 
 When the job exits, you'll still have Bash access to the job.
 
+## Restore And Save Cache
+
+Run jobs faster when you cache dependencies.
+
+Local CI supports the [native](https://circleci.com/docs/2.0/caching/) `restore_cache` and `save_cache` values:
+
+![Editor with restore cache](https://user-images.githubusercontent.com/4063887/146306642-87ccc2c3-5e99-467e-ae41-70ecaef1bcc6.png)
+
 ## Run The Whole Workflow
 
 You can even run jobs that depend on other jobs, because this persists the workspace between jobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "local-ci",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "local-ci",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "os": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "local-ci",
   "displayName": "Local CI",
   "description": "Debug CircleCI® workflows locally, with Bash access during and after. Free preview, then paid.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "publisher": "LocalCI",
   "contributors": [
     "Ryan Kienstra"

--- a/package.json
+++ b/package.json
@@ -57,46 +57,51 @@
     "commands": [
       {
         "command": "local-ci.job.run",
-        "title": "Run Local CI job",
+        "title": "Local CI: Run Job",
         "icon": "$(refresh)"
       },
       {
         "command": "local-ci.job.exit",
-        "title": "Exit Job",
+        "title": "Local CI: Exit Job",
         "icon": "$(notebook-delete-cell)"
       },
       {
         "command": "local-ci.job.rerun",
-        "title": "Rerun Job",
+        "title": "Local CI: Rerun Job",
         "icon": "$(extensions-refresh)"
       },
       {
         "command": "local-ci.debug.repo",
-        "title": "Run Jobs Locally (Local CI)"
+        "title": "Local CI: Run Jobs Locally (Local CI)"
+      },
+      {
+        "command": "localCiJobs.enterToken",
+        "title": "Local CI: Enter API Token",
+        "icon": "$(record-keys)"
       },
       {
         "command": "localCiJobs.refresh",
-        "title": "Refresh Job List",
+        "title": "Local CI: Refresh Job List",
         "icon": "$(refresh)"
       },
       {
         "command": "localCiJobs.help",
-        "title": "Help",
+        "title": "Local CI: Help",
         "icon": "$(question)"
       },
       {
         "command": "localCiJobs.exitAllJobs",
-        "title": "Exit All Jobs",
+        "title": "Local CI: Exit All Jobs",
         "icon": "$(notebook-delete-cell)"
       },
       {
         "command": "localCiJobs.selectRepo",
-        "title": "Select Repo ",
+        "title": "Local CI: Select Repo ",
         "icon": "$(debug-configure)"
       },
       {
         "command": "localCiLicense.refresh",
-        "title": "Refresh License Information",
+        "title": "Local CI: Refresh License Information",
         "icon": "$(refresh)"
       }
     ],
@@ -111,6 +116,11 @@
       "view/title": [
         {
           "command": "localCiJobs.refresh",
+          "when": "view == localCiJobs",
+          "group": "navigation"
+        },
+        {
+          "command": "localCiJobs.enterToken",
           "when": "view == localCiJobs",
           "group": "navigation"
         },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
       },
       {
         "command": "local-ci.debug.repo",
-        "title": "Local CI: Run Jobs Locally (Local CI)"
+        "title": "Local CI: Run Jobs Locally"
       },
       {
         "command": "localCiJobs.enterToken",
@@ -80,9 +80,9 @@
         "icon": "$(record-keys)"
       },
       {
-        "command": "localCiJobs.refresh",
-        "title": "Local CI: Refresh Job List",
-        "icon": "$(refresh)"
+        "command": "localCiJobs.exitAllJobs",
+        "title": "Local CI: Exit All Jobs",
+        "icon": "$(notebook-delete-cell)"
       },
       {
         "command": "localCiJobs.help",
@@ -90,9 +90,9 @@
         "icon": "$(question)"
       },
       {
-        "command": "localCiJobs.exitAllJobs",
-        "title": "Local CI: Exit All Jobs",
-        "icon": "$(notebook-delete-cell)"
+        "command": "localCiJobs.refresh",
+        "title": "Local CI: Refresh Job List",
+        "icon": "$(refresh)"
       },
       {
         "command": "localCiJobs.selectRepo",
@@ -115,12 +115,12 @@
     "menus": {
       "view/title": [
         {
-          "command": "localCiJobs.refresh",
+          "command": "localCiJobs.enterToken",
           "when": "view == localCiJobs",
           "group": "navigation"
         },
         {
-          "command": "localCiJobs.enterToken",
+          "command": "localCiJobs.exitAllJobs",
           "when": "view == localCiJobs",
           "group": "navigation"
         },
@@ -130,7 +130,7 @@
           "group": "navigation"
         },
         {
-          "command": "localCiJobs.exitAllJobs",
+          "command": "localCiJobs.refresh",
           "when": "view == localCiJobs",
           "group": "navigation"
         },

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-export const EXTENSION_VERSION = '1.3.0';
+export const EXTENSION_VERSION = '1.3.1';
 export const EXTENSION_ID = 'LocalCI.local-ci';
 export const COMMITTED_IMAGE_NAMESPACE = 'local-ci';
 export const SELECTED_CONFIG_PATH = 'local-ci.config.path';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -49,7 +49,7 @@ export const HAS_EXTENDED_TRIAL = 'local-ci.license.trial-extended.survey';
 export const TRIAL_STARTED_TIMESTAMP =
   'local-ci.license.trial-started.timestamp';
 export const CONTAINER_STORAGE_DIRECTORY = '/tmp/local-ci';
-export const HOST_TMP_DIRECTORY = '/tmp/local-ci'; // Also hard-coded in node/uninstall.js, change that if this changes.
+export const HOST_TMP_DIRECTORY = '/tmp/local-ci'; // Also hard-coded in node/uninstall.js, change that if this changes. Be careful changing this, as there's an rm -rf for it.
 export const PROCESS_FILE_DIRECTORY = `${HOST_TMP_DIRECTORY}/process`;
 export const LOCAL_VOLUME_DIRECTORY = `${HOST_TMP_DIRECTORY}/volume`;
 export const RUN_JOB_COMMAND = 'local-ci.job.run';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
+import { getBinaryPath } from '../node/binary';
 import Delayer from './classes/Delayer';
 import Job from './classes/Job';
 import JobProvider from './classes/JobProvider';
@@ -74,9 +75,23 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand(`${JOB_TREE_VIEW_ID}.refresh`, () =>
       jobProvider.refresh()
     ),
-    vscode.commands.registerCommand(`${JOB_TREE_VIEW_ID}.help`, () =>
-      vscode.env.openExternal(vscode.Uri.parse(HELP_URL))
-    ),
+    vscode.commands.registerCommand(`${JOB_TREE_VIEW_ID}.enterToken`, () => {
+      const terminal = vscode.window.createTerminal({
+        name: 'Store CircleCI® token',
+        message: `Please get a CircleCI® API token: https://circleci.com/docs/2.0/managing-api-tokens/ This will store the token on your local machine, Local CI won't do anything with that token other than run CircleCI jobs. If you'd rather store the token on your own, please follow these instructions to install the CircleCI CLI: https://circleci.com/docs/2.0/local-cli/ Then, run this Bash command: circleci setup. This token isn't necessary for all jobs, so you might not have to enter a token.`,
+        iconPath: vscode.Uri.joinPath(
+          context.extensionUri,
+          'resources',
+          'logo.svg'
+        ),
+      });
+      terminal.show();
+      terminal.sendText(`${getBinaryPath()} setup`);
+    }),
+    vscode.commands.registerCommand(`${JOB_TREE_VIEW_ID}.help`, () => {
+      reporter.sendTelemetryEvent('help');
+      vscode.env.openExternal(vscode.Uri.parse(HELP_URL));
+    }),
     vscode.commands.registerCommand(`${JOB_TREE_VIEW_ID}.exitAllJobs`, () => {
       reporter.sendTelemetryEvent('exitAllJobs');
       jobProvider.refresh();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,7 +77,7 @@ export function activate(context: vscode.ExtensionContext): void {
     ),
     vscode.commands.registerCommand(`${JOB_TREE_VIEW_ID}.enterToken`, () => {
       const terminal = vscode.window.createTerminal({
-        name: 'Store CircleCI® token',
+        name: 'Enter CircleCI® API Token',
         message: `Please get a CircleCI® API token: https://circleci.com/docs/2.0/managing-api-tokens/ This will store the token on your local machine, Local CI won't do anything with that token other than run CircleCI jobs. If you'd rather store the token on your own, please follow these instructions to install the CircleCI CLI: https://circleci.com/docs/2.0/local-cli/ Then, run this Bash command: circleci setup. This token isn't necessary for all jobs, so you might not have to enter a token.`,
         iconPath: vscode.Uri.joinPath(
           context.extensionUri,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import Delayer from './classes/Delayer';
@@ -13,6 +14,7 @@ import {
   GET_LICENSE_COMMAND,
   GET_LICENSE_KEY_URL,
   HELP_URL,
+  HOST_TMP_DIRECTORY,
   JOB_TREE_VIEW_ID,
   RUN_JOB_COMMAND,
   SELECTED_CONFIG_PATH,
@@ -300,4 +302,5 @@ export function activate(context: vscode.ExtensionContext): void {
 
 export function deactivate(): void {
   reporter.sendTelemetryEvent('deactivate');
+  fs.rmSync(HOST_TMP_DIRECTORY, { recursive: true, force: true });
 }


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Open a terminal to enter an API token on clicking or entering the command
* Many times, and API token isn't needed
* But there can be an error in the job that it can't pull a Docker image

