### PR TITLE
Get the extension version from `package.json`, not a constant

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,3 @@
-export const EXTENSION_VERSION = '1.3.2';
 export const EXTENSION_ID = 'LocalCI.local-ci';
 export const COMMITTED_IMAGE_NAMESPACE = 'local-ci';
 export const SELECTED_CONFIG_PATH = 'local-ci.config.path';
@@ -7,16 +6,6 @@ export const GET_LICENSE_COMMAND = 'local-ci.license.get';
 export const ENTER_LICENSE_COMMAND = 'local-ci.license.enter';
 export const EXIT_JOB_COMMAND = 'local-ci.job.exit';
 
-// @todo: Look at an alternative, as docker inspect hangs sometimes: https://github.com/docker/for-linux/issues/397
-export const GET_CONTAINER_FUNCTION = `get_container() {
-  IMAGE=$1
-  for container in $(docker ps -q); do
-    if [[ $IMAGE == $(docker inspect --format '{{.Config.Image}}' $container) ]]; then
-      echo $container
-      break
-    fi
-  done
-}`;
 export const GET_RUNNING_CONTAINER_FUNCTION = `get_running_container() {
   IMAGE=$1
   for container in $(docker ps -q --filter status=running); do

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,6 @@ import {
   ENTER_LICENSE_COMMAND,
   EXIT_JOB_COMMAND,
   EXTENSION_ID,
-  EXTENSION_VERSION,
   GET_LICENSE_COMMAND,
   GET_LICENSE_KEY_URL,
   HELP_URL,
@@ -39,7 +38,7 @@ import writeProcessFile from './utils/writeProcessFile';
 
 const reporter = new TelemetryReporter(
   EXTENSION_ID,
-  EXTENSION_VERSION,
+  vscode.extensions.getExtension(EXTENSION_ID)?.packageJSON.version,
   TELEMETRY_KEY
 );
 
@@ -82,7 +81,7 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand(`${JOB_TREE_VIEW_ID}.enterToken`, () => {
       const terminal = vscode.window.createTerminal({
         name: 'Enter CircleCI® API Token',
-        message: `Please get a CircleCI® API token: https://circleci.com/docs/2.0/managing-api-tokens/ This will store the token on your local machine, Local CI won't do anything with that token other than run CircleCI jobs. If you'd rather store the token on your own, please follow these instructions to install the CircleCI CLI: https://circleci.com/docs/2.0/local-cli/ Then, run this Bash command: circleci setup. This token isn't necessary for all jobs, so you might not have to enter a token.`,
+        message: `Please get a CircleCI® API token: https://circleci.com/account/api This will store the token on your local machine, Local CI won't do anything with that token other than run CircleCI jobs. If you'd rather store the token on your own, please follow these instructions to install the CircleCI CLI: https://circleci.com/docs/2.0/local-cli/ Then, run this Bash command: circleci setup. This token isn't necessary for all jobs, so you might not have to enter a token.`,
         iconPath: vscode.Uri.joinPath(
           context.extensionUri,
           'resources',


### PR DESCRIPTION

<!--- Please summarize this PR in the title above -->

#### Changes
* Gets the version from `packages.json`
* Should be easier to release without worrying about incrementing the version.


