### PR TITLE
Rename `getRootPath()` to be more clear

### DIFF
--- a/src/test/suite/utils/getFirstWorkspaceRootPath.test.ts
+++ b/src/test/suite/utils/getFirstWorkspaceRootPath.test.ts
@@ -2,16 +2,16 @@ import * as assert from 'assert';
 import * as mocha from 'mocha';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import getRootPath from '../../../utils/getRootPath';
+import getFirstWorkspaceRootPath from '../../../utils/getFirstWorkspaceRootPath';
 
 mocha.afterEach(() => {
   sinon.restore();
 });
 
-suite('getRootPath', () => {
+suite('getFirstWorkspaceRootPath', () => {
   test('With no workspaceFolders', () => {
     sinon.stub(vscode, 'workspace').value({});
-    assert.strictEqual(getRootPath(), '');
+    assert.strictEqual(getFirstWorkspaceRootPath(), '');
   });
 
   test('With workspaceFolders', () => {
@@ -24,6 +24,6 @@ suite('getRootPath', () => {
       ],
     });
 
-    assert.strictEqual(getRootPath(), path);
+    assert.strictEqual(getFirstWorkspaceRootPath(), path);
   });
 });

--- a/src/utils/getFirstWorkspaceRootPath.ts
+++ b/src/utils/getFirstWorkspaceRootPath.ts
@@ -2,7 +2,9 @@ import * as vscode from 'vscode';
 
 // Gets the absolute path to this VS Code workspace.
 // @todo: handle multiple workspaceFolders.
-export default function getRootPath(): string {
+// Only gets the 1st workspaceFolder,
+// though there could be several.
+export default function getFirstWorkspaceRootPath(): string {
   return vscode.workspace?.workspaceFolders?.length
     ? vscode.workspace.workspaceFolders[0]?.uri?.path
     : '';

--- a/src/utils/getFirstWorkspaceRootPath.ts
+++ b/src/utils/getFirstWorkspaceRootPath.ts
@@ -1,9 +1,7 @@
 import * as vscode from 'vscode';
 
-// Gets the absolute path to this VS Code workspace.
-// @todo: handle multiple workspaceFolders.
-// Only gets the 1st workspaceFolder,
-// though there could be several.
+// Gets the absolute path to this 1st VS Code workspace folder.
+// Though there could be several workspace folders.
 export default function getFirstWorkspaceRootPath(): string {
   return vscode.workspace?.workspaceFolders?.length
     ? vscode.workspace.workspaceFolders[0]?.uri?.path

--- a/src/utils/getLicenseInformation.ts
+++ b/src/utils/getLicenseInformation.ts
@@ -43,9 +43,9 @@ export default async function getLicenseInformation(
     trialLengthInMilliseconds
   );
 
-  const isPreviewExpiredByOneDay = isTrialExpired(
+  const isPreviewExpiredByTwoDays = isTrialExpired(
     previewStartedTimeStamp,
-    trialLengthInMilliseconds + dayInMilliseconds
+    trialLengthInMilliseconds + 2 * dayInMilliseconds
   );
 
   if (isValid) {
@@ -66,7 +66,7 @@ export default async function getLicenseInformation(
     <p>${complainLink}</p>`;
   }
 
-  if (isPreviewExpiredByOneDay) {
+  if (isPreviewExpiredByTwoDays) {
     return `<p>${scheduleInterviewLink}</p>
       <p>No sales pitch, I have nothing to sell you after giving you the free lifetime license.</p>
       <p>${enterLicenseButton}</p>`;

--- a/src/utils/getSpawnOptions.ts
+++ b/src/utils/getSpawnOptions.ts
@@ -1,9 +1,9 @@
-import getRootPath from './getRootPath';
+import getFirstWorkspaceRootPath from './getFirstWorkspaceRootPath';
 import getPath from './getPath';
 
 export default function getSpawnOptions(cwd?: string): SpawnOptions {
   return {
-    cwd: cwd || getRootPath(),
+    cwd: cwd || getFirstWorkspaceRootPath(),
     env: {
       ...process.env,
       PATH: getPath(), // eslint-disable-line @typescript-eslint/naming-convention


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Rename `getRootPath()` 
* Change license offer to 2 days after


