### PR TITLE
Improve detection of job success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.4.1 - 3 January 2022
+
+### Added
+- Improve detection of job success. [#67](https://github.com/getlocalci/local-ci/pull/67/)
+- Add a 'Learn more' link when there's no `.circleci/config.yml`. [#67](https://github.com/getlocalci/local-ci/pull/67/)
+
 ## 1.4.0 - 2 January 2022
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "local-ci",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "local-ci",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "os": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "local-ci",
   "displayName": "Local CI",
   "description": "Debug CircleCI® workflows locally, with Bash access during and after. Free preview, then paid.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "publisher": "LocalCI",
   "contributors": [
     "Ryan Kienstra"

--- a/src/classes/JobProvider.ts
+++ b/src/classes/JobProvider.ts
@@ -17,6 +17,7 @@ import {
   ENTER_LICENSE_COMMAND,
   GET_LICENSE_COMMAND,
   JOB_TREE_VIEW_ID,
+  OPEN_LEARN_MORE_COMMAND,
   TRIAL_STARTED_TIMESTAMP,
 } from '../constants';
 
@@ -174,6 +175,7 @@ export default class JobProvider
           new vscode.TreeItem(
             'Please add a .circleci/config.yml to this workspace'
           ),
+          new Command('Learn more', OPEN_LEARN_MORE_COMMAND),
         ];
       case JobError.noConfigFilePathSelected:
         return [

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -43,6 +43,9 @@ export const HOST_TMP_DIRECTORY = '/tmp/local-ci'; // Also hard-coded in node/un
 export const PROCESS_FILE_DIRECTORY = `${HOST_TMP_DIRECTORY}/process`;
 export const LOCAL_VOLUME_DIRECTORY = `${HOST_TMP_DIRECTORY}/volume`;
 export const RUN_JOB_COMMAND = 'local-ci.job.run';
+export const OPEN_LEARN_MORE_COMMAND = 'local-ci.open.learn-more.config';
+export const CONFIG_LEARN_MORE_URL =
+  'https://circleci.com/docs/2.0/config-intro/';
 export const CONTINUE_PIPELINE_STEP_NAME = 'Continue the pipeline';
 export const SCHEDULE_INTERVIEW_URL =
   'https://tidycal.com/localci/30-minute-meeting';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import JobProvider from './classes/JobProvider';
 import LicenseProvider from './classes/LicenseProvider';
 import {
   COMMITTED_IMAGE_NAMESPACE,
+  CONFIG_LEARN_MORE_URL,
   ENTER_LICENSE_COMMAND,
   EXIT_JOB_COMMAND,
   EXTENSION_ID,
@@ -16,6 +17,7 @@ import {
   HELP_URL,
   HOST_TMP_DIRECTORY,
   JOB_TREE_VIEW_ID,
+  OPEN_LEARN_MORE_COMMAND,
   RUN_JOB_COMMAND,
   SELECTED_CONFIG_PATH,
   TELEMETRY_KEY,
@@ -122,6 +124,8 @@ export function activate(context: vscode.ExtensionContext): void {
       `${JOB_TREE_VIEW_ID}.selectRepo`,
       async () => {
         reporter.sendTelemetryEvent('selectRepo');
+
+        const learnMoreText = 'Learn more';
         const quickPick = vscode.window.createQuickPick();
         const configFilePaths = await getAllConfigFilePaths(context);
         quickPick.title = 'Repo to run CI on';
@@ -133,8 +137,14 @@ export function activate(context: vscode.ExtensionContext): void {
                 description:
                   'Please add a .circleci/config.yml file so Local CI can run',
               },
+              {
+                label: learnMoreText,
+              },
             ];
         quickPick.onDidChangeSelection((selection) => {
+          if (selection.length && selection[0].label === learnMoreText) {
+            vscode.commands.executeCommand(OPEN_LEARN_MORE_COMMAND);
+          }
           if (
             selection?.length &&
             (selection[0] as ConfigFileQuickPick)?.fsPath
@@ -286,6 +296,10 @@ export function activate(context: vscode.ExtensionContext): void {
         licenseCompletedCallback,
         licenseSuccessCallback
       );
+    }),
+    vscode.commands.registerCommand(OPEN_LEARN_MORE_COMMAND, () => {
+      reporter.sendTelemetryEvent('click.config.learnMore');
+      vscode.env.openExternal(vscode.Uri.parse(CONFIG_LEARN_MORE_URL));
     })
   );
 

--- a/src/utils/getConfigFilePath.ts
+++ b/src/utils/getConfigFilePath.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { SELECTED_CONFIG_PATH } from '../constants';
+import { OPEN_LEARN_MORE_COMMAND, SELECTED_CONFIG_PATH } from '../constants';
 import getAllConfigFilePaths from './getAllConfigFilePaths';
 
 // Gets the path of the selected .circleci/config.yml to run the jobs on.
@@ -19,10 +19,19 @@ export default async function getConfigFilePath(
 
   const allConfigFilePaths = await getAllConfigFilePaths(context);
   if (!allConfigFilePaths.length) {
-    vscode.window.showInformationMessage(
-      'Please add a .circleci/config.yml file so Local CI can run it',
-      { detail: 'There is no config file for Local CI to run' }
-    );
+    const learnMoreText = 'Learn more';
+    vscode.window
+      .showInformationMessage(
+        'Please add a .circleci/config.yml file so Local CI can run it',
+        { detail: 'There is no config file for Local CI to run' },
+        learnMoreText
+      )
+      .then((clicked) => {
+        if (clicked === learnMoreText) {
+          vscode.commands.executeCommand(OPEN_LEARN_MORE_COMMAND);
+        }
+      });
+
     return '';
   }
 

--- a/src/utils/showMainTerminalHelperMessages.ts
+++ b/src/utils/showMainTerminalHelperMessages.ts
@@ -31,12 +31,9 @@ export default function showMainTerminalHelperMessages(
       return;
     }
 
-    // 'Sucess!' should be near the end of the output, to find the final job 'Success!' message.
-    // There can be lot of other 'Success!' messages that can trigger this incorrectly.
-    if (
-      output?.includes('Success!') &&
-      output.length - output.indexOf('Success!') < 15
-    ) {
+    // This should be the final 'Success!' message when a job succeeds.
+    // There can be lot of other 'Success!' messages that might trigger this incorrectly.
+    if (output?.includes(`[32mSuccess![0m`)) {
       job?.setIsSuccess();
 
       if (doesJobCreateDynamicConfig) {

--- a/src/utils/showMainTerminalHelperMessages.ts
+++ b/src/utils/showMainTerminalHelperMessages.ts
@@ -26,7 +26,17 @@ export default function showMainTerminalHelperMessages(
   );
 
   process.stdout.on('data', (data) => {
-    if (data?.toString()?.includes('Success!')) {
+    const output = data?.toString();
+    if (!output.length) {
+      return;
+    }
+
+    // 'Sucess!' should be near the end of the output, to find the final job 'Success!' message.
+    // There can be lot of other 'Success!' messages that can trigger this incorrectly.
+    if (
+      output?.includes('Success!') &&
+      output.length - output.indexOf('Success!') < 15
+    ) {
       job?.setIsSuccess();
 
       if (doesJobCreateDynamicConfig) {
@@ -39,12 +49,12 @@ export default function showMainTerminalHelperMessages(
       }
     }
 
-    if (data?.toString()?.includes('Task failed')) {
+    if (output.includes('Task failed')) {
       job?.setIsFailure();
       jobProvider.refresh(job);
     }
 
-    if (data?.toString()?.includes(memoryMessage)) {
+    if (output.includes(memoryMessage)) {
       vscode.window.showInformationMessage(
         `This may have failed from a lack of Docker memory. You can increase it via Docker Desktop > Preferences > Resources > Advanced > Memory`
       );

--- a/src/utils/showMainTerminalHelperMessages.ts
+++ b/src/utils/showMainTerminalHelperMessages.ts
@@ -46,12 +46,12 @@ export default function showMainTerminalHelperMessages(
       }
     }
 
-    if (output.includes('Task failed')) {
+    if (output?.includes('Task failed')) {
       job?.setIsFailure();
       jobProvider.refresh(job);
     }
 
-    if (output.includes(memoryMessage)) {
+    if (output?.includes(memoryMessage)) {
       vscode.window.showInformationMessage(
         `This may have failed from a lack of Docker memory. You can increase it via Docker Desktop > Preferences > Resources > Advanced > Memory`
       );

--- a/src/utils/showMainTerminalHelperMessages.ts
+++ b/src/utils/showMainTerminalHelperMessages.ts
@@ -27,7 +27,7 @@ export default function showMainTerminalHelperMessages(
 
   process.stdout.on('data', (data) => {
     const output = data?.toString();
-    if (!output.length) {
+    if (!output?.length) {
       return;
     }
 


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* There can be a lot of 'Success!' substrings in a job
* Improve the detection so it ideally only runs at the end
* Add a 'Learn more' link when there's no `.circleci/config.yml`
