### PR TITLE
Bump version to 1.4.2, add a `CHANGELOG` entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+
+## 1.4.2 - 4 January 2022
+
+### Added
+- Optionally create a config file when none exists. [#69](https://github.com/getlocalci/local-ci/pull/69/)
+- Bump `vsce` package to the latest version. [#68](https://github.com/getlocalci/local-ci/pull/68/)
+
 ## 1.4.1 - 3 January 2022
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Change Log
 
-
 ## 1.4.2 - 4 January 2022
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "local-ci",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "local-ci",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "os": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "local-ci",
   "displayName": "Local CI",
   "description": "Debug CircleCI® workflows locally, with Bash access during and after. Free preview, then paid.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "publisher": "LocalCI",
   "contributors": [
     "Ryan Kienstra"


### PR DESCRIPTION


#### Changes
* Bump extension version
* Add a `CHANGELOG` entry

