### PR TITLE
Fix a bug where `save_cache` wasn't recognized

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "ts-loader": "^9.2.2",
         "typescript": "^4.5.5",
         "util": "^0.12.4",
-        "vsce": "^2.6.5",
+        "vsce": "^2.6.7",
         "vscode-test": "^1.6.1",
         "webpack": "^5.38.1",
         "webpack-cli": "^4.9.2"
@@ -4991,9 +4991,9 @@
       "dev": true
     },
     "node_modules/vsce": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.5.tgz",
-      "integrity": "sha512-KB3m0CDlWZCKwjQx2oSg35vWgTNrcOPcL6DGLVGewKhadwbL2OWGRoMRKUUFFtPFKwp3BwuTvEM5fENG/AQ5Lg==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.7.tgz",
+      "integrity": "sha512-5dEtdi/yzWQbOU7JDUSOs8lmSzzkewBR5P122BUkmXE6A/DEdFsKNsg2773NGXJTwwF1MfsOgUR6QVF3cLLJNQ==",
       "dev": true,
       "dependencies": {
         "azure-devops-node-api": "^11.0.1",
@@ -9202,9 +9202,9 @@
       "dev": true
     },
     "vsce": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.5.tgz",
-      "integrity": "sha512-KB3m0CDlWZCKwjQx2oSg35vWgTNrcOPcL6DGLVGewKhadwbL2OWGRoMRKUUFFtPFKwp3BwuTvEM5fENG/AQ5Lg==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.7.tgz",
+      "integrity": "sha512-5dEtdi/yzWQbOU7JDUSOs8lmSzzkewBR5P122BUkmXE6A/DEdFsKNsg2773NGXJTwwF1MfsOgUR6QVF3cLLJNQ==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -306,7 +306,7 @@
     "ts-loader": "^9.2.2",
     "typescript": "^4.5.5",
     "util": "^0.12.4",
-    "vsce": "^2.6.5",
+    "vsce": "^2.6.7",
     "vscode-test": "^1.6.1",
     "webpack": "^5.38.1",
     "webpack-cli": "^4.9.2"

--- a/src/utils/getRestoreCacheCommand.ts
+++ b/src/utils/getRestoreCacheCommand.ts
@@ -2,21 +2,21 @@ import * as path from 'path';
 import convertToBash from './convertToBash';
 import { CONTAINER_STORAGE_DIRECTORY } from '../constants';
 
-// @todo: handle restore_cache having .keys.
 export default function getRestoreCacheCommand(
   restoreCacheStep: FullStep,
   saveCacheSteps: (SaveCache | undefined)[]
 ): string | undefined {
   const originalSaveCacheStep = saveCacheSteps.find(
     (saveCacheStep) =>
-      saveCacheStep?.key === restoreCacheStep?.restore_cache?.key ||
-      restoreCacheStep?.restore_cache?.keys?.some(
-        (restoreCacheKey) => restoreCacheKey === saveCacheStep?.key
+      (!!restoreCacheStep?.restore_cache?.key &&
+        saveCacheStep?.key.includes(restoreCacheStep?.restore_cache?.key)) ||
+      restoreCacheStep?.restore_cache?.keys?.some((restoreCacheKey) =>
+        saveCacheStep?.key.includes(restoreCacheKey)
       )
   );
 
   if (!originalSaveCacheStep) {
-    return '';
+    return `echo "No save_cache directory found, so nothing to restore"`;
   }
 
   return originalSaveCacheStep?.paths.reduce((accumulator, saveCachePath) => {


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

## Background
The `restore_cache` and `save_cache` keys don't have to match exactly.

For example, this `restore_cache` key: 

```
node-deps-{{ arch }}-v1-{{ .Branch }}-
```

…matches the beginning of this `save_cache` key: 

```
node-deps-{{ arch }}-v1-{{ .Branch }}-{{ checksum "/tmp/node-project-package.json" }}-{{ checksum "/tmp/node-project-lockfile" }}
```

…and that's enough.

## Testing instructions
* Run `js-build` from https://github.com/getlocalci/circleci-tutorial-for-beginners/blob/182025eddf6a3159fadcd72c66d3c70c091f016d/.circleci/config.yml locally