### PR TITLE
Use of `yq` for cleaner terminal output

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ CI jobs can fail because of wrong dependency versions, or flaky combinations of 
 
 You'll get local Bash access to jobs, so you'll usually be able to see what's wrong and fix it.
 
-Thanks to [CirleCI-Public/cirlceci-cli](https://github.com/circleci-public/circleci-cli), which this uses.
+Thanks to [CirleCI-Public/cirlceci-cli](https://github.com/circleci-public/circleci-cli) and [mikefarah/yq](https://github.com/mikefarah/yq), which this uses.
 
 CircleCI® is a registered trademark of Circle Internet Services, Inc.
 
@@ -51,7 +51,7 @@ Find out in seconds whether the setup is right, all in your local.
 
 ## License Key
 
-Local CI requires a [license key](https://getlocalci.com/pricing/?utm_medium=extension&utm_source=readme) for $50 per month.
+Local CI requires a [license key](https://getlocalci.com/pricing/?utm_medium=extension&utm_source=readme) for $10 per month.
 
 But first you'll get a free 2-day preview, no sign-up or credit card needed.
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -207,6 +207,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
         if (context.globalState.get(doNotConfirmRunJob)) {
           runJob(context, jobName, jobProvider, job);
+          return;
         }
 
         const confirmText = 'Yes';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,23 +211,23 @@ export function activate(context: vscode.ExtensionContext): void {
         }
 
         const confirmText = 'Yes';
-        const doNotAskAgainText = `Don't ask again`;
+        const dontAskAgainText = `Yes, don't ask again`;
         vscode.window
           .showInformationMessage(
             `Do you want to run the job ${jobName}?`,
             { modal: true },
             { title: confirmText },
-            { title: doNotAskAgainText }
+            { title: dontAskAgainText }
           )
           .then((selection) => {
             if (
               selection?.title === confirmText ||
-              selection?.title === doNotAskAgainText
+              selection?.title === dontAskAgainText
             ) {
               runJob(context, jobName, jobProvider, job);
             }
 
-            if (selection?.title === doNotAskAgainText) {
+            if (selection?.title === dontAskAgainText) {
               context.globalState.update(doNotConfirmRunJob, true);
             }
           });
@@ -242,7 +242,7 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('local-ci.job.rerun', async (job: Job) => {
       const jobName = job.getJobName();
       const confirmText = 'Yes';
-      const doNotAskAgainText = `Don't ask again`;
+      const dontAskAgainText = `Yes, don't ask again`;
 
       async function rerunJob() {
         job.setIsRunning();
@@ -255,6 +255,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
       if (context.globalState.get(doNotConfirmRunJob)) {
         rerunJob();
+        return;
       }
 
       vscode.window
@@ -262,17 +263,17 @@ export function activate(context: vscode.ExtensionContext): void {
           `Do you want to rerun the job ${jobName}?`,
           { modal: true },
           { title: confirmText },
-          { title: doNotAskAgainText }
+          { title: dontAskAgainText }
         )
         .then(async (selection) => {
           if (
             selection?.title === confirmText ||
-            selection?.title === doNotAskAgainText
+            selection?.title === dontAskAgainText
           ) {
             rerunJob();
           }
 
-          if (selection?.title === doNotAskAgainText) {
+          if (selection?.title === dontAskAgainText) {
             context.globalState.update(doNotConfirmRunJob, true);
           }
         });

--- a/src/utils/runJob.ts
+++ b/src/utils/runJob.ts
@@ -101,11 +101,13 @@ export default async function runJob(
 
   // This allows persisting files between jobs with persist_to_workspace and attach_workspace.
   const volume = `${localVolume}:${CONTAINER_STORAGE_DIRECTORY}`;
+  const jobConfigPath = isJobInDynamicConfig
+    ? dynamicConfigFilePath
+    : processFilePath;
 
   terminal.sendText(
-    `${getBinaryPath()} local execute --job '${jobName}' --config ${
-      isJobInDynamicConfig ? dynamicConfigFilePath : processFilePath
-    } -v ${volume} --debug`
+    `cat ${jobConfigPath} | docker run -i --rm mikefarah/yq -C
+    ${getBinaryPath()} local execute --job '${jobName}' --config ${jobConfigPath} -v ${volume}`
   );
 
   const committedImageRepo = `${COMMITTED_IMAGE_NAMESPACE}/${jobName}`;


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

## Changes
* Thanks to a user's suggestion, this uses https://github.com/mikefarah/yq/ for terminal output: ![pretty-printed-yml](https://user-images.githubusercontent.com/4063887/158732251-a6dcada4-8ef8-404e-9e9e-b403065b3466.png)

* There's still a lot of work needed in https://github.com/getlocalci/local-ci/pull/95/, like having another log file they can open after the job exits
* But this PR will allow releasing the work that's done 
