### PR TITLE
Remove terminal characters from logs

### DIFF
--- a/src/utils/listenToJob.ts
+++ b/src/utils/listenToJob.ts
@@ -77,7 +77,13 @@ export default function listenToJob(
       return;
     }
 
-    fs.appendFileSync(logFilePath, output.replace(/\[[0-9]+m/g, '')); // eslint-disable-line no-control-regex
+    fs.appendFileSync(
+      logFilePath,
+      // Remove terminal color encoding, like [32m
+      // Convert this: [32mSuccess![0m
+      // To: Success!
+      output.replace(/\[[0-9]+m/g, '') // eslint-disable-line no-control-regex
+    );
 
     // This should be the final 'Success!' message when a job succeeds.
     // There are a lot of other 'Success!' messages that might trigger this incorrectly.

--- a/src/utils/listenToJob.ts
+++ b/src/utils/listenToJob.ts
@@ -77,7 +77,7 @@ export default function listenToJob(
       return;
     }
 
-    fs.appendFileSync(logFilePath, output);
+    fs.appendFileSync(logFilePath, output.replace(/\[[0-9]+m/g, '')); // eslint-disable-line no-control-regex
 
     // This should be the final 'Success!' message when a job succeeds.
     // There are a lot of other 'Success!' messages that might trigger this incorrectly.


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

## Change
Remove terminal characters from logs

<img width="388" alt="Screen Shot 2022-05-01 at 3 39 14 PM" src="https://user-images.githubusercontent.com/4063887/166163748-7fb45a51-9cbb-49c4-a223-5ae6ce8f80eb.png">

## Before
<img width="941" alt="terminal-colors" src="https://user-images.githubusercontent.com/4063887/166163968-316d1fa3-b8a8-43ab-a937-8df1bf34aac5.png">

## After
<img width="943" alt="Screen Shot 2022-05-01 at 3 31 10 PM" src="https://user-images.githubusercontent.com/4063887/166163504-5c6ab443-9cdd-4213-8696-da57116245f8.png">



