### PR TITLE
Possibly add support for Linux arm64

### DIFF
--- a/node/binary.js
+++ b/node/binary.js
@@ -18,6 +18,11 @@ const supportedPlatforms = [
     url: "https://github.com/CircleCI-Public/circleci-cli/releases/download/v0.1.17554/circleci-cli_0.1.17554_linux_amd64.tar.gz",
   },
   {
+    type: "Linux",
+    architecture: "arm64",
+    url: "https://github.com/CircleCI-Public/circleci-cli/releases/download/v0.1.17554/circleci-cli_0.1.17554_linux_arm64.tar.gz",
+  },
+  {
     type: "Darwin",
     architecture: "x64",
     url: "https://github.com/CircleCI-Public/circleci-cli/releases/download/v0.1.17087/circleci-cli_0.1.17087_darwin_amd64.tar.gz",


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Possibly add support for Linux arm64, thanks so CircleCI's [new arm64 binary](https://github.com/CircleCI-Public/circleci-cli/releases/tag/v0.1.17554)
* But haven't tested this, as I don't have an arm Linux

