### PR TITLE
Ask new users for an email, though this still works without it

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -33,7 +33,8 @@ export const GET_PICARD_CONTAINER_FUNCTION = `get_picard_container() {
 }`;
 export const GET_LICENSE_KEY_URL =
   'https://getlocalci.com/pricing/?utm_medium=extension&utm_source=ui';
-export const EMAIL_ENDPOINT = 'https://getlocalci.com/wp-json/gf/v2/entries';
+export const EMAIL_ENDPOINT =
+  'https://getlocalci.com/wp-json/gf-integration/v1/email';
 export const HELP_URL = 'https://github.com/getlocalci/local-ci/discussions';
 export const JOB_TREE_VIEW_ID = 'localCiJobs';
 export const LICENSE_ITEM_ID = 43;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -33,6 +33,9 @@ export const GET_PICARD_CONTAINER_FUNCTION = `get_picard_container() {
 }`;
 export const GET_LICENSE_KEY_URL =
   'https://getlocalci.com/pricing/?utm_medium=extension&utm_source=ui';
+export const EMAIL_ENDPOINT = 'https://getlocalci.com/wp-json/gf/v2/entries';
+export const EMAIL_AUTHORIZATION_HEADER =
+  'Basic Y2tfYThkZmRlYzcxYTNkNTUxM2I1NmI5N2I0NzdhODk0ODU4NTg1ZWUzZjpjc19hYzNlNWFiNjMzNGRlNjcyOTZjYmNhNmVjYmM3MDVjYzMwMzU4ZTUw';
 export const HELP_URL = 'https://github.com/getlocalci/local-ci/discussions';
 export const JOB_TREE_VIEW_ID = 'localCiJobs';
 export const LICENSE_ITEM_ID = 43;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -34,8 +34,6 @@ export const GET_PICARD_CONTAINER_FUNCTION = `get_picard_container() {
 export const GET_LICENSE_KEY_URL =
   'https://getlocalci.com/pricing/?utm_medium=extension&utm_source=ui';
 export const EMAIL_ENDPOINT = 'https://getlocalci.com/wp-json/gf/v2/entries';
-export const EMAIL_AUTHORIZATION_HEADER =
-  'Y2tfYThkZmRlYzcxYTNkNTUxM2I1NmI5N2I0NzdhODk0ODU4NTg1ZWUzZjpjc19hYzNlNWFiNjMzNGRlNjcyOTZjYmNhNmVjYmM3MDVjYzMwMzU4ZTUw';
 export const HELP_URL = 'https://github.com/getlocalci/local-ci/discussions';
 export const JOB_TREE_VIEW_ID = 'localCiJobs';
 export const LICENSE_ITEM_ID = 43;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -35,7 +35,7 @@ export const GET_LICENSE_KEY_URL =
   'https://getlocalci.com/pricing/?utm_medium=extension&utm_source=ui';
 export const EMAIL_ENDPOINT = 'https://getlocalci.com/wp-json/gf/v2/entries';
 export const EMAIL_AUTHORIZATION_HEADER =
-  'Basic Y2tfYThkZmRlYzcxYTNkNTUxM2I1NmI5N2I0NzdhODk0ODU4NTg1ZWUzZjpjc19hYzNlNWFiNjMzNGRlNjcyOTZjYmNhNmVjYmM3MDVjYzMwMzU4ZTUw';
+  'Y2tfYThkZmRlYzcxYTNkNTUxM2I1NmI5N2I0NzdhODk0ODU4NTg1ZWUzZjpjc19hYzNlNWFiNjMzNGRlNjcyOTZjYmNhNmVjYmM3MDVjYzMwMzU4ZTUw';
 export const HELP_URL = 'https://github.com/getlocalci/local-ci/discussions';
 export const JOB_TREE_VIEW_ID = 'localCiJobs';
 export const LICENSE_ITEM_ID = 43;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ const reporter = new TelemetryReporter(
 const doNotConfirmRunJob = 'local-ci.job.do-not-confirm';
 
 export function activate(context: vscode.ExtensionContext): void {
-  if (context.globalState.get(TRIAL_STARTED_TIMESTAMP)) {
+  if (!context.globalState.get(TRIAL_STARTED_TIMESTAMP)) {
     context.globalState.update(TRIAL_STARTED_TIMESTAMP, new Date().getTime());
     reporter.sendTelemetryEvent('firstActivation');
     askForEmail();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,7 @@ import prepareConfig from './utils/prepareConfig';
 import runJob from './utils/runJob';
 import showLicenseInput from './utils/showLicenseInput';
 import showLogFile from './utils/showLogFile';
+import askForEmail from './utils/askForEmail';
 
 const reporter = new TelemetryReporter(
   EXTENSION_ID,
@@ -52,9 +53,10 @@ const reporter = new TelemetryReporter(
 const doNotConfirmRunJob = 'local-ci.job.do-not-confirm';
 
 export function activate(context: vscode.ExtensionContext): void {
-  if (!context.globalState.get(TRIAL_STARTED_TIMESTAMP)) {
+  if (context.globalState.get(TRIAL_STARTED_TIMESTAMP)) {
     context.globalState.update(TRIAL_STARTED_TIMESTAMP, new Date().getTime());
     reporter.sendTelemetryEvent('firstActivation');
+    askForEmail();
 
     const getStartedText = 'Get started debugging faster';
     vscode.window

--- a/src/test/suite/utils/sendEnteredEmail.test.ts
+++ b/src/test/suite/utils/sendEnteredEmail.test.ts
@@ -11,25 +11,23 @@ mocha.afterEach(() => {
 });
 
 suite('sendEnteredEmail', () => {
-  test('only email', () => {
+  test('only email', async () => {
     const email = 'a@example.com';
 
     const spy = sinon.spy();
     sinon.stub(axios, 'post').value(spy);
 
-    sendEnteredEmail(email);
+    await sendEnteredEmail(email);
     assert(
       spy.calledOnceWith(EMAIL_ENDPOINT, {
-        form_id: 5,
-        '1': undefined,
-        '3': email,
-        '4.1': undefined,
-        '4.2': undefined,
+        name: undefined,
+        email,
+        optedIn: undefined,
       })
     );
   });
 
-  test('all fields', () => {
+  test('all fields', async () => {
     const email = 'a@example.com';
     const name = 'Jane';
     const optedIn = true;
@@ -37,14 +35,12 @@ suite('sendEnteredEmail', () => {
     const spy = sinon.spy();
     sinon.stub(axios, 'post').value(spy);
 
-    sendEnteredEmail(email, name, optedIn);
+    await sendEnteredEmail(email, name, optedIn);
     assert(
       spy.calledOnceWith(EMAIL_ENDPOINT, {
-        form_id: 5,
-        '1': name,
-        '3': email,
-        '4.1': '1',
-        '4.2': 'yes',
+        name,
+        email,
+        optedIn,
       })
     );
   });

--- a/src/test/suite/utils/sendEnteredEmail.test.ts
+++ b/src/test/suite/utils/sendEnteredEmail.test.ts
@@ -1,0 +1,51 @@
+import * as assert from 'assert';
+import * as mocha from 'mocha';
+import * as sinon from 'sinon';
+import axios from 'axios';
+
+import sendEnteredEmail from '../../../utils/sendEnteredEmail';
+import { EMAIL_ENDPOINT } from '../../../constants';
+
+mocha.afterEach(() => {
+  sinon.restore();
+});
+
+suite('sendEnteredEmail', () => {
+  test('only email', () => {
+    const email = 'a@example.com';
+
+    const spy = sinon.spy();
+    sinon.stub(axios, 'post').value(spy);
+
+    sendEnteredEmail(email);
+    assert(
+      spy.calledOnceWith(EMAIL_ENDPOINT, {
+        form_id: 5,
+        '1': undefined,
+        '3': email,
+        '4.1': undefined,
+        '4.2': undefined,
+      })
+    );
+  });
+
+  test('all fields', () => {
+    const email = 'a@example.com';
+    const name = 'Jane';
+    const optedIn = true;
+
+    const spy = sinon.spy();
+    sinon.stub(axios, 'post').value(spy);
+
+    sendEnteredEmail(email, name, optedIn);
+    assert(
+      spy.calledOnceWith(EMAIL_ENDPOINT, {
+        form_id: 5,
+        '1': name,
+        '3': email,
+        '4.1': '1',
+        '4.2': 'yes',
+      })
+    );
+  });
+});

--- a/src/utils/askForEmail.ts
+++ b/src/utils/askForEmail.ts
@@ -27,7 +27,7 @@ export default function askForEmail(): void {
           const yesText = 'Yes';
           vscode.window
             .showQuickPick(['No', yesText], {
-              title: `Thanks a lot! Can I send you occasional emails with CI/CD tips? You can unsubscribe any time. I'll never share your email.`,
+              title: `Thanks so much! Can I send you occasional emails with CI/CD tips? You can unsubscribe any time. I'll never share your email.`,
             })
             .then(async (selection) => {
               const optedIntoNewsletter = selection === yesText;

--- a/src/utils/askForEmail.ts
+++ b/src/utils/askForEmail.ts
@@ -20,7 +20,8 @@ export default function askForEmail(): void {
         })
         .then((enteredName) => {
           if (enteredName === undefined) {
-            sendEnteredEmail(enteredEmail);
+            sendEnteredEmail(enteredEmail); // They pressed Escape or exited the input box.
+            return;
           }
 
           const yesText = 'Yes';

--- a/src/utils/askForEmail.ts
+++ b/src/utils/askForEmail.ts
@@ -4,7 +4,7 @@ import sendEnteredEmail from './sendEnteredEmail';
 export default function askForEmail(): void {
   vscode.window
     .showInputBox({
-      title: 'Local CI Extension',
+      title: 'Email',
       prompt:
         'Could you please enter your email for your free preview of Local CI?',
     })
@@ -15,8 +15,8 @@ export default function askForEmail(): void {
 
       vscode.window
         .showInputBox({
-          title: 'Local CI license key',
-          prompt: 'Thanks! Could you please enter your first name?',
+          title: 'Name',
+          prompt: `Thanks a lot! What's your first name?`,
         })
         .then((enteredName) => {
           if (enteredName === undefined) {

--- a/src/utils/askForEmail.ts
+++ b/src/utils/askForEmail.ts
@@ -1,0 +1,42 @@
+import * as vscode from 'vscode';
+import sendEnteredEmail from './sendEnteredEmail';
+
+export default function askForEmail(): void {
+  vscode.window
+    .showInputBox({
+      title: 'Local CI Extension',
+      prompt:
+        'Could you please enter your email for your free preview of Local CI?',
+    })
+    .then((enteredEmail) => {
+      if (enteredEmail === undefined) {
+        return; // They pressed Escape or exited the input box.
+      }
+
+      vscode.window
+        .showInputBox({
+          title: 'Local CI license key',
+          prompt: 'Thanks! Could you please enter your first name?',
+        })
+        .then((enteredName) => {
+          if (enteredName === undefined) {
+            sendEnteredEmail(enteredEmail);
+          }
+
+          const yesText = 'Yes';
+          vscode.window
+            .showQuickPick(['No', yesText], {
+              title: `Thanks a lot! Can I send you occasional emails with CI/CD tips? You can unsubscribe any time. I'll never share your email.`,
+            })
+            .then(async (selection) => {
+              const optedIntoNewsletter = selection === yesText;
+
+              vscode.window.showInformationMessage(
+                'Thanks a lot, your free preview has started!',
+                { detail: 'Local CI free preview' }
+              );
+              sendEnteredEmail(enteredEmail, enteredName, optedIntoNewsletter);
+            });
+        });
+    });
+}

--- a/src/utils/sendEnteredEmail.ts
+++ b/src/utils/sendEnteredEmail.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { EMAIL_AUTHORIZATION_HEADER, EMAIL_ENDPOINT } from '../constants';
+import { EMAIL_ENDPOINT } from '../constants';
 
 export default function sendEnteredEmail(
   email: string,
@@ -17,7 +17,7 @@ export default function sendEnteredEmail(
     },
     {
       headers: {
-        Authorization: `Basic ${EMAIL_AUTHORIZATION_HEADER}`,
+        Authorization: `Basic`,
       },
     }
   );

--- a/src/utils/sendEnteredEmail.ts
+++ b/src/utils/sendEnteredEmail.ts
@@ -17,7 +17,7 @@ export default function sendEnteredEmail(
     },
     {
       headers: {
-        Authorization: EMAIL_AUTHORIZATION_HEADER,
+        Authorization: `Basic ${EMAIL_AUTHORIZATION_HEADER}`,
       },
     }
   );

--- a/src/utils/sendEnteredEmail.ts
+++ b/src/utils/sendEnteredEmail.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import { EMAIL_AUTHORIZATION_HEADER, EMAIL_ENDPOINT } from '../constants';
+
+export default function sendEnteredEmail(
+  email: string,
+  name?: string,
+  optedIntoNewsletter?: boolean
+): void {
+  axios.post(
+    EMAIL_ENDPOINT,
+    {
+      form_id: 5,
+      '1': name,
+      '3': email,
+      '4.1': optedIntoNewsletter ? '1' : undefined,
+      '4.2': optedIntoNewsletter ? 'yes' : undefined,
+    },
+    {
+      headers: {
+        Authorization: EMAIL_AUTHORIZATION_HEADER,
+      },
+    }
+  );
+}

--- a/src/utils/sendEnteredEmail.ts
+++ b/src/utils/sendEnteredEmail.ts
@@ -1,24 +1,14 @@
 import axios from 'axios';
 import { EMAIL_ENDPOINT } from '../constants';
 
-export default function sendEnteredEmail(
+export default async function sendEnteredEmail(
   email: string,
   name?: string,
-  optedIntoNewsletter?: boolean
-): void {
-  axios.post(
-    EMAIL_ENDPOINT,
-    {
-      form_id: 5,
-      '1': name,
-      '3': email,
-      '4.1': optedIntoNewsletter ? '1' : undefined,
-      '4.2': optedIntoNewsletter ? 'yes' : undefined,
-    },
-    {
-      headers: {
-        Authorization: `Basic`,
-      },
-    }
-  );
+  optedIn?: boolean
+): Promise<void> {
+  await axios.post(EMAIL_ENDPOINT, {
+    name,
+    email,
+    optedIn,
+  });
 }


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Add an email prompt for new users, though this still works without an email
* You can dismiss the prompt simply by clicking outside of it, or clicking Escape: 
![clicking-ouside](https://user-images.githubusercontent.com/4063887/171071839-213dc274-230b-4c36-96ed-c1423ad1916e.gif)

#### Background
* I feel dirty doing this. It seems against open source.
* But I need more user feedback to keep going with Local CI. 
* There are a lot of users that start a trial and don't continue. I don't know how to improve Local CI or help them without getting in touch with those that want to share their email.

