### PR TITLE
Bump the CLI version for everything but Intel Mac

### DIFF
--- a/node/binary.js
+++ b/node/binary.js
@@ -3,7 +3,7 @@ const { Binary } = require('@cloudflare/binary-install');
 const { type, arch } = require('os');
 const path = require('path');
 
-const binaryVersion = '0.1.18980';
+const binaryVersion = '0.1.19626';
 const intelMacBinaryVersion = '0.1.17087';
 
 const supportedPlatforms = [


### PR DESCRIPTION
* Bump the [CLI version](https://github.com/CircleCI-Public/circleci-cli/releases/tag/v0.1.19626) for everything but Intel Mac
* That is still on an older version so it can still run

<!--- Please summarize this PR in the title above -->

