### PR TITLE
Add a `CIRCLE_PROJECT_REPONAME` env var

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ This will also run on a pre-commit hook that will install on `npm i`
 
 You may want to downlod and install a development `.vsix` file, instead of installing this extension via the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=LocalCI.local-ci).
 
-You'll need at least a [free CircleCI account](https://circleci.com/signup/) for this.
+You'll need to be logged into at least a [free CircleCI account](https://circleci.com/signup/) for this.
 
 Also, it'd be good to use Firefox instead of Chrome. It looks like Chrome converts the `.vsix` file into an unusable `.zip` file on downloading it.
 

--- a/src/test/expected/dynamic-config.yml
+++ b/src/test/expected/dynamic-config.yml
@@ -17,7 +17,7 @@ jobs:
           command: |-
             echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
-            echo 'export CIRCLE_PROJECT_REPONAME=$(basename `git rev-parse --show-toplevel`)' >> $BASH_ENV
+            echo 'export CIRCLE_PROJECT_REPONAME=$(basename `git remote get-url origin`)' >> $BASH_ENV
 
       - run:
           name: Create config

--- a/src/test/expected/dynamic-config.yml
+++ b/src/test/expected/dynamic-config.yml
@@ -17,7 +17,7 @@ jobs:
           command: |-
             echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
-            echo 'export CIRCLE_PROJECT_REPONAME=$(basename `git remote get-url origin`)' >> $BASH_ENV
+            echo 'export CIRCLE_PROJECT_REPONAME=$(basename $git remote get-url origin))' >> $BASH_ENV
 
       - run:
           name: Create config

--- a/src/test/expected/dynamic-config.yml
+++ b/src/test/expected/dynamic-config.yml
@@ -17,7 +17,7 @@ jobs:
           command: |-
             echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
-            echo 'export CIRCLE_PROJECT_REPONAME=$(basename $git remote get-url origin))' >> $BASH_ENV
+            echo 'export CIRCLE_PROJECT_REPONAME=$(basename $(git remote get-url origin))' >> $BASH_ENV
 
       - run:
           name: Create config

--- a/src/test/expected/dynamic-config.yml
+++ b/src/test/expected/dynamic-config.yml
@@ -17,6 +17,8 @@ jobs:
           command: |-
             echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
+            echo 'export CIRCLE_PROJECT_REPONAME=$(basename `git rev-parse --show-toplevel`)' >> $BASH_ENV
+
       - run:
           name: Create config
           command: echo "Creating the dynamic config here"

--- a/src/test/expected/with-cache.yml
+++ b/src/test/expected/with-cache.yml
@@ -20,7 +20,7 @@ jobs:
           command: |-
             echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
-            echo 'export CIRCLE_PROJECT_REPONAME=$(basename `git remote get-url origin`)' >> $BASH_ENV
+            echo 'export CIRCLE_PROJECT_REPONAME=$(basename $(git remote get-url origin))' >> $BASH_ENV
 
       - run:
           name: Restore cache

--- a/src/test/expected/with-cache.yml
+++ b/src/test/expected/with-cache.yml
@@ -20,7 +20,7 @@ jobs:
           command: |-
             echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
-            echo 'export CIRCLE_PROJECT_REPONAME=$(basename `git rev-parse --show-toplevel`)' >> $BASH_ENV
+            echo 'export CIRCLE_PROJECT_REPONAME=$(basename `git remote get-url origin`)' >> $BASH_ENV
 
       - run:
           name: Restore cache

--- a/src/test/expected/with-cache.yml
+++ b/src/test/expected/with-cache.yml
@@ -20,6 +20,8 @@ jobs:
           command: |-
             echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
+            echo 'export CIRCLE_PROJECT_REPONAME=$(basename `git rev-parse --show-toplevel`)' >> $BASH_ENV
+
       - run:
           name: Restore cache
           command: >

--- a/src/utils/writeProcessFile.ts
+++ b/src/utils/writeProcessFile.ts
@@ -55,7 +55,8 @@ function getEnvVarStep() {
     run: {
       name: 'Set more environment variables',
       command: `echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
-        echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV`,
+        echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
+        echo 'export CIRCLE_PROJECT_REPONAME=$(basename $(git rev-parse --show-toplevel))' >> $BASH_ENV`,
     },
   };
 }

--- a/src/utils/writeProcessFile.ts
+++ b/src/utils/writeProcessFile.ts
@@ -56,7 +56,7 @@ function getEnvVarStep() {
       name: 'Set more environment variables',
       command: `echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
         echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
-        echo 'export CIRCLE_PROJECT_REPONAME=$(basename $(git rev-parse --show-toplevel))' >> $BASH_ENV`,
+        echo 'export CIRCLE_PROJECT_REPONAME=$(basename $(git remote get-url origin))' >> $BASH_ENV`,
     },
   };
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@
 
 const path = require('path');
 
-/**@type {import('webpack').Configuration}*/
+/** @type {import('webpack').Configuration} */
 const config = {
   target: 'node',
   mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Add a `CIRCLE_PROJECT_REPONAME` env var
* This is normally set when CircleCI® runs
* It's like the GitHub slug of the project


