### PR TITLE
Ensure sudo is installed before calling it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       - checkout
       - node/install-packages
       - run: npm test
+    resource_class: large
   package:
     docker:
       - image: cimg/node:16.8.0-browsers

--- a/src/test/expected/dynamic-config.yml
+++ b/src/test/expected/dynamic-config.yml
@@ -7,7 +7,7 @@ jobs:
       - run:
           name: Ensure volume is writable
           command: |-
-            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ]
+            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi

--- a/src/test/expected/dynamic-config.yml
+++ b/src/test/expected/dynamic-config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci

--- a/src/test/expected/with-cache.yml
+++ b/src/test/expected/with-cache.yml
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - run:
           name: Set more environment variables
-          command: |
+          command: |-
             echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_PROJECT_REPONAME=$(basename $(git remote get-url origin))' >> $BASH_ENV
@@ -90,7 +90,7 @@ jobs:
             fi
       - run:
           name: Attach workspace
-          command: |
+          command: |-
             if [ ! -d /tmp/local-ci ]
               then
                 echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -129,7 +129,7 @@ jobs:
             fi
       - run:
           name: Attach workspace
-          command: |
+          command: |-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -154,7 +154,7 @@ jobs:
             fi
       - run:
           name: Attach workspace
-          command: |
+          command: |-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -179,7 +179,7 @@ jobs:
             fi
       - run:
           name: Attach workspace
-          command: |
+          command: |-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -229,7 +229,7 @@ jobs:
             fi
       - run:
           name: Attach workspace
-          command: |
+          command: |-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -257,7 +257,7 @@ jobs:
             fi
       - run:
           name: Attach workspace
-          command: |
+          command: |-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -282,7 +282,7 @@ jobs:
             fi
       - run:
           name: Attach workspace
-          command: |
+          command: |-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."

--- a/src/test/expected/with-cache.yml
+++ b/src/test/expected/with-cache.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: |
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - run:
           name: Set more environment variables
-          command: |-
+          command: |
             echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_PROJECT_REPONAME=$(basename $(git remote get-url origin))' >> $BASH_ENV
@@ -83,14 +83,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: |
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: |
             if [ ! -d /tmp/local-ci ]
               then
                 echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -122,14 +122,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: |
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: |
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -147,14 +147,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: |
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: |
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -172,14 +172,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: |
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: |
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -222,14 +222,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: |
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: |
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -250,14 +250,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: |
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: |
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -275,14 +275,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: |
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: |
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -294,7 +294,7 @@ jobs:
             fi
       - run:
           name: Firebase deploy
-          command: |-
+          command: |
             if [[ "$CIRCLE_BRANCH" == "master" ]]
               then
               npm run firebase:deploy:ci

--- a/src/test/expected/with-cache.yml
+++ b/src/test/expected/with-cache.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: Ensure volume is writable
           command: |-
-            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ]
+            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
@@ -84,7 +84,7 @@ jobs:
       - run:
           name: Ensure volume is writable
           command: |-
-            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ]
+            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Ensure volume is writable
           command: |-
-            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ]
+            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
@@ -148,7 +148,7 @@ jobs:
       - run:
           name: Ensure volume is writable
           command: |-
-            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ]
+            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
@@ -173,7 +173,7 @@ jobs:
       - run:
           name: Ensure volume is writable
           command: |-
-            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ]
+            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
@@ -223,7 +223,7 @@ jobs:
       - run:
           name: Ensure volume is writable
           command: |-
-            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ]
+            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
@@ -251,7 +251,7 @@ jobs:
       - run:
           name: Ensure volume is writable
           command: |-
-            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ]
+            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
@@ -276,7 +276,7 @@ jobs:
       - run:
           name: Ensure volume is writable
           command: |-
-            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ]
+            if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi

--- a/src/test/expected/with-cache.yml
+++ b/src/test/expected/with-cache.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
@@ -83,7 +83,7 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
@@ -122,7 +122,7 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
@@ -147,7 +147,7 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
@@ -172,7 +172,7 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
@@ -222,7 +222,7 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
@@ -250,7 +250,7 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
@@ -275,7 +275,7 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci

--- a/src/test/expected/with-cache.yml
+++ b/src/test/expected/with-cache.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: >-
+          command: |-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - run:
           name: Set more environment variables
-          command: >-
+          command: |-
             echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_PROJECT_REPONAME=$(basename $(git remote get-url origin))' >> $BASH_ENV
@@ -83,14 +83,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: >-
+          command: |-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: >-
+          command: |-
             if [ ! -d /tmp/local-ci ]
               then
                 echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -122,14 +122,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: >-
+          command: |-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: >-
+          command: |-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -147,14 +147,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: >-
+          command: |-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: >-
+          command: |-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -172,14 +172,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: >-
+          command: |-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: >-
+          command: |-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -222,14 +222,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: >-
+          command: |-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: >-
+          command: |-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -250,14 +250,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: >-
+          command: |-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: >-
+          command: |-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -275,14 +275,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: >-
+          command: |-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: >-
+          command: |-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -294,7 +294,7 @@ jobs:
             fi
       - run:
           name: Firebase deploy
-          command: |
+          command: |-
             if [[ "$CIRCLE_BRANCH" == "master" ]]
               then
               npm run firebase:deploy:ci

--- a/src/test/expected/with-cache.yml
+++ b/src/test/expected/with-cache.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - run:
           name: Set more environment variables
-          command: |-
+          command: >-
             echo 'export CIRCLE_SHA1=$(git rev-parse HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> $BASH_ENV
             echo 'export CIRCLE_PROJECT_REPONAME=$(basename $(git remote get-url origin))' >> $BASH_ENV
@@ -83,14 +83,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: >-
             if [ ! -d /tmp/local-ci ]
               then
                 echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -122,14 +122,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: >-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -147,14 +147,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: >-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -172,14 +172,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: >-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -222,14 +222,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: >-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -250,14 +250,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: >-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."
@@ -275,14 +275,14 @@ jobs:
     steps:
       - run:
           name: Ensure volume is writable
-          command: |-
+          command: >-
             if [ "$(ls -ld /tmp/local-ci | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
               then
               sudo chown $(whoami) /tmp/local-ci
             fi
       - run:
           name: Attach workspace
-          command: |-
+          command: >-
             if [ ! -d /tmp/local-ci ]
             then
               echo "Warning: tried to attach_workspace to /tmp/local-ci, but it's not a directory. It might require a job to run before it."

--- a/src/utils/writeProcessFile.ts
+++ b/src/utils/writeProcessFile.ts
@@ -42,7 +42,7 @@ function getEnsureVolumeIsWritableStep() {
   return {
     run: {
       name: 'Ensure volume is writable',
-      command: `if [ "$(ls -ld ${CONTAINER_STORAGE_DIRECTORY} | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
+      command: `if [ "$(ls -ld ${CONTAINER_STORAGE_DIRECTORY} | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ] && [ "$(sudo -V 2>/dev/null)" ]
         then
         sudo chown $(whoami) ${CONTAINER_STORAGE_DIRECTORY}
       fi`,

--- a/src/utils/writeProcessFile.ts
+++ b/src/utils/writeProcessFile.ts
@@ -42,7 +42,7 @@ function getEnsureVolumeIsWritableStep() {
   return {
     run: {
       name: 'Ensure volume is writable',
-      command: `if [ "$(ls -ld ${CONTAINER_STORAGE_DIRECTORY} | awk '{print $3}')" != "$(whoami)" ]
+      command: `if [ "$(ls -ld ${CONTAINER_STORAGE_DIRECTORY} | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
         then
         sudo chown $(whoami) ${CONTAINER_STORAGE_DIRECTORY}
       fi`,

--- a/src/utils/writeProcessFile.ts
+++ b/src/utils/writeProcessFile.ts
@@ -42,7 +42,7 @@ function getEnsureVolumeIsWritableStep() {
   return {
     run: {
       name: 'Ensure volume is writable',
-      command: `if [ "$(ls -ld ${CONTAINER_STORAGE_DIRECTORY} | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ] && [ "$(sudo -V 2>/dev/null)" ]
+      command: `if [ "$(ls -ld ${CONTAINER_STORAGE_DIRECTORY} | awk '{print $3}')" != "$(whoami)" ] && [ "$(sudo -V 2>/dev/null)" ]
         then
         sudo chown $(whoami) ${CONTAINER_STORAGE_DIRECTORY}
       fi`,


### PR DESCRIPTION
* Sometimes there's an error: `sudo: command not found`
* Ensure sudo is installed before calling it
* Do `sudo -V`, and check that there's a non-empty result.

<!--- Please summarize this PR in the title above -->
