### PR TITLE
Open the extension tab on selecting a repo

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,6 +192,10 @@ export function activate(context: vscode.ExtensionContext): void {
                 vscode.window.showInformationMessage(
                   `The repo ${getRepoBasename(selectedFsPath)} is now selected`
                 );
+
+                vscode.commands.executeCommand(
+                  'workbench.view.extension.localCiDebugger'
+                );
               });
           }
 
@@ -212,7 +216,7 @@ export function activate(context: vscode.ExtensionContext): void {
       async (jobName: string, job?: Job) => {
         if (!jobName) {
           vscode.window.showWarningMessage(
-            `Please click a specific job to run it`
+            'Please click a specific job to run it'
           );
           vscode.commands.executeCommand(
             'workbench.view.extension.localCiDebugger'


### PR DESCRIPTION
It's a little strange to select a repo and then see no change, only the notice.
Now, choosing a repo shows the Local CI UI:

![chossing-a-repo](https://user-images.githubusercontent.com/4063887/180330303-42f29b91-3417-4b27-b0f9-84ebab3da5e4.gif)


