### PR TITLE
Fix the check for whether Docker is running

### DIFF
--- a/src/utils/getDockerError.ts
+++ b/src/utils/getDockerError.ts
@@ -3,7 +3,7 @@ import getSpawnOptions from './getSpawnOptions';
 
 export default function getDockerError(): string {
   try {
-    cp.execSync('docker -v', {
+    cp.execSync('docker info', {
       ...getSpawnOptions(),
       timeout: 2000,
     });


### PR DESCRIPTION
* Use `docker info` instead of `docker -v`
* `docker -v` can pass even if it's not running
* Now, it shows the warning, as expected:
<img width="507" alt="Screen Shot 2022-07-23 at 3 23 42 PM" src="https://user-images.githubusercontent.com/4063887/180621656-bb35ba95-ca36-451b-bf06-69be18f1cc0c.png">


Fixes https://github.com/getlocalci/local-ci/issues/59
