### PR TITLE
Use sha256sum if shasum doesn't produce anything

### DIFF
--- a/src/test/expected/with-cache.yml
+++ b/src/test/expected/with-cache.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Restore cache
           command: >
-            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )*/.npm" "/tmp/local-ci/v2-deps*/.npm")
+            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )*/.npm" "/tmp/local-ci/v2-deps*/.npm")
               for directory_candidate in $restore_from_directories
                 do
                 if [ $(ls -ard $directory_candidate 2>/dev/null) ]
@@ -36,7 +36,7 @@ jobs:
                   break;
                 fi
               done;
-            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )*/.cache" "/tmp/local-ci/v2-deps*/.cache")
+            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )*/.cache" "/tmp/local-ci/v2-deps*/.cache")
               for directory_candidate in $restore_from_directories
                 do
                 if [ $(ls -ard $directory_candidate 2>/dev/null) ]
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: Save cache
           command: |2
-             if [ -d /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/.npm ]
+             if [ -d /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )/.npm ]
                   then
                   echo "~/.npm is already cached, skipping"
                 elif [ ! -d ~/.npm ]
@@ -61,10 +61,10 @@ jobs:
                   echo "~/.npm does not exist, skipping caching"
                 else
                   echo "Saving ~/.npm to the cache"
-                  mkdir -p /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )
-                  cp -rn ~/.npm /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/.npm || cp -ru ~/.npm /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/.npm
+                  mkdir -p /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )
+                  cp -rn ~/.npm /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )/.npm || cp -ru ~/.npm /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )/.npm
                 fi
-             if [ -d /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/.cache ]
+             if [ -d /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )/.cache ]
                   then
                   echo "~/.cache is already cached, skipping"
                 elif [ ! -d ~/.cache ]
@@ -72,8 +72,8 @@ jobs:
                   echo "~/.cache does not exist, skipping caching"
                 else
                   echo "Saving ~/.cache to the cache"
-                  mkdir -p /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )
-                  cp -rn ~/.cache /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/.cache || cp -ru ~/.cache /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/.cache
+                  mkdir -p /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )
+                  cp -rn ~/.cache /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )/.cache || cp -ru ~/.cache /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )/.cache
                 fi
       - run:
           name: Persist to workspace
@@ -106,7 +106,7 @@ jobs:
       - run:
           name: Save cache
           command: |2
-            if [ -d /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/node_modules ]
+            if [ -d /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )/node_modules ]
               then
               echo "node_modules is already cached, skipping"
             elif [ ! -d node_modules ]
@@ -114,8 +114,8 @@ jobs:
               echo "node_modules does not exist, skipping caching"
             else
               echo "Saving node_modules to the cache"
-              mkdir -p /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )
-              cp -rn node_modules /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/node_modules || cp -ru node_modules /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/node_modules
+              mkdir -p /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )
+              cp -rn node_modules /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )/node_modules || cp -ru node_modules /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )/node_modules
             fi
   run-linter:
     executor: default-executor
@@ -192,7 +192,7 @@ jobs:
       - run:
           name: Restore cache
           command: >
-            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )*/.npm" "/tmp/local-ci/v2-deps*/.npm" "/tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )*/.npm")
+            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )*/.npm" "/tmp/local-ci/v2-deps*/.npm" "/tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )*/.npm")
             for directory_candidate in $restore_from_directories
               do
               if [ $(ls -ard $directory_candidate 2>/dev/null) ]
@@ -203,7 +203,7 @@ jobs:
                 break;
               fi
             done;
-            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )*/.cache" "/tmp/local-ci/v2-deps*/.cache" "/tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )*/.cache")
+            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )*/.cache" "/tmp/local-ci/v2-deps*/.cache" "/tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null  | awk '{print $1}'; fi )*/.cache")
             for directory_candidate in $restore_from_directories
               do
               if [ $(ls -ard $directory_candidate 2>/dev/null) ]

--- a/src/test/expected/with-cache.yml
+++ b/src/test/expected/with-cache.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Restore cache
           command: >
-            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )*/.npm" "/tmp/local-ci/v2-deps*/.npm")
+            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )*/.npm" "/tmp/local-ci/v2-deps*/.npm")
               for directory_candidate in $restore_from_directories
                 do
                 if [ $(ls -ard $directory_candidate 2>/dev/null) ]
@@ -36,7 +36,7 @@ jobs:
                   break;
                 fi
               done;
-            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )*/.cache" "/tmp/local-ci/v2-deps*/.cache")
+            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )*/.cache" "/tmp/local-ci/v2-deps*/.cache")
               for directory_candidate in $restore_from_directories
                 do
                 if [ $(ls -ard $directory_candidate 2>/dev/null) ]
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: Save cache
           command: |2
-             if [ -d /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )/.npm ]
+             if [ -d /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/.npm ]
                   then
                   echo "~/.npm is already cached, skipping"
                 elif [ ! -d ~/.npm ]
@@ -61,10 +61,10 @@ jobs:
                   echo "~/.npm does not exist, skipping caching"
                 else
                   echo "Saving ~/.npm to the cache"
-                  mkdir -p /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )
-                  cp -rn ~/.npm /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )/.npm || cp -ru ~/.npm /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )/.npm
+                  mkdir -p /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )
+                  cp -rn ~/.npm /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/.npm || cp -ru ~/.npm /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/.npm
                 fi
-             if [ -d /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )/.cache ]
+             if [ -d /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/.cache ]
                   then
                   echo "~/.cache is already cached, skipping"
                 elif [ ! -d ~/.cache ]
@@ -72,8 +72,8 @@ jobs:
                   echo "~/.cache does not exist, skipping caching"
                 else
                   echo "Saving ~/.cache to the cache"
-                  mkdir -p /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )
-                  cp -rn ~/.cache /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )/.cache || cp -ru ~/.cache /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )/.cache
+                  mkdir -p /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )
+                  cp -rn ~/.cache /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/.cache || cp -ru ~/.cache /tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/.cache
                 fi
       - run:
           name: Persist to workspace
@@ -106,7 +106,7 @@ jobs:
       - run:
           name: Save cache
           command: |2
-            if [ -d /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )/node_modules ]
+            if [ -d /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/node_modules ]
               then
               echo "node_modules is already cached, skipping"
             elif [ ! -d node_modules ]
@@ -114,8 +114,8 @@ jobs:
               echo "node_modules does not exist, skipping caching"
             else
               echo "Saving node_modules to the cache"
-              mkdir -p /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )
-              cp -rn node_modules /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )/node_modules || cp -ru node_modules /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )/node_modules
+              mkdir -p /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )
+              cp -rn node_modules /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/node_modules || cp -ru node_modules /tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )/node_modules
             fi
   run-linter:
     executor: default-executor
@@ -192,7 +192,7 @@ jobs:
       - run:
           name: Restore cache
           command: >
-            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )*/.npm" "/tmp/local-ci/v2-deps*/.npm" "/tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )*/.npm")
+            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )*/.npm" "/tmp/local-ci/v2-deps*/.npm" "/tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )*/.npm")
             for directory_candidate in $restore_from_directories
               do
               if [ $(ls -ard $directory_candidate 2>/dev/null) ]
@@ -203,7 +203,7 @@ jobs:
                 break;
               fi
             done;
-            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )*/.cache" "/tmp/local-ci/v2-deps*/.cache" "/tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )*/.cache")
+            restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )*/.cache" "/tmp/local-ci/v2-deps*/.cache" "/tmp/local-ci/node-modules-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2> /dev/null  | awk '{print $1}'; fi )*/.cache")
             for directory_candidate in $restore_from_directories
               do
               if [ $(ls -ard $directory_candidate 2>/dev/null) ]

--- a/src/test/suite/utils/getRestoreCacheCommand.test.ts
+++ b/src/test/suite/utils/getRestoreCacheCommand.test.ts
@@ -31,7 +31,7 @@ suite('getRestoreCacheCommand', () => {
         )
       ),
       normalize(
-        `restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null "package-lock.json" || sha256sum "package-lock.json" 2>/dev/null "package-lock.json" | awk '{print $1}'; fi )*/.npm")
+        `restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null "package-lock.json" || sha256sum "package-lock.json" 2>/dev/null | awk '{print $1}'; fi )*/.npm")
         for directory_candidate in $restore_from_directories
           do
           if [ $(ls -ard $directory_candidate 2>/dev/null) ]
@@ -41,7 +41,7 @@ suite('getRestoreCacheCommand', () => {
             break;
           fi
         done;
-        restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null "package-lock.json" | awk '{print $1}'; fi )*/.cache")
+        restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null | awk '{print $1}'; fi )*/.cache")
         for directory_candidate in $restore_from_directories
           do
           if [ $(ls -ard $directory_candidate 2>/dev/null) ]
@@ -78,7 +78,7 @@ suite('getRestoreCacheCommand', () => {
         )
       ),
       normalize(
-        `restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null "package-lock.json" | awk '{print $1}'; fi )*/.npm" "/tmp/local-ci/v2-deps*/.npm")
+        `restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null | awk '{print $1}'; fi )*/.npm" "/tmp/local-ci/v2-deps*/.npm")
         for directory_candidate in $restore_from_directories
           do
           if [ $(ls -ard $directory_candidate 2>/dev/null) ]
@@ -89,7 +89,7 @@ suite('getRestoreCacheCommand', () => {
             break;
           fi
         done;
-        restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null "package-lock.json" | awk '{print $1}'; fi )*/.cache" "/tmp/local-ci/v2-deps*/.cache")
+        restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null | awk '{print $1}'; fi )*/.cache" "/tmp/local-ci/v2-deps*/.cache")
         for directory_candidate in $restore_from_directories
           do
           if [ $(ls -ard $directory_candidate 2>/dev/null) ]

--- a/src/test/suite/utils/getRestoreCacheCommand.test.ts
+++ b/src/test/suite/utils/getRestoreCacheCommand.test.ts
@@ -31,7 +31,7 @@ suite('getRestoreCacheCommand', () => {
         )
       ),
       normalize(
-        `restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )*/.npm")
+        `restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null "package-lock.json" || sha256sum "package-lock.json" 2>/dev/null "package-lock.json" | awk '{print $1}'; fi )*/.npm")
         for directory_candidate in $restore_from_directories
           do
           if [ $(ls -ard $directory_candidate 2>/dev/null) ]
@@ -41,7 +41,7 @@ suite('getRestoreCacheCommand', () => {
             break;
           fi
         done;
-        restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )*/.cache")
+        restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null "package-lock.json" | awk '{print $1}'; fi )*/.cache")
         for directory_candidate in $restore_from_directories
           do
           if [ $(ls -ard $directory_candidate 2>/dev/null) ]
@@ -78,7 +78,7 @@ suite('getRestoreCacheCommand', () => {
         )
       ),
       normalize(
-        `restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )*/.npm" "/tmp/local-ci/v2-deps*/.npm")
+        `restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null "package-lock.json" | awk '{print $1}'; fi )*/.npm" "/tmp/local-ci/v2-deps*/.npm")
         for directory_candidate in $restore_from_directories
           do
           if [ $(ls -ard $directory_candidate 2>/dev/null) ]
@@ -89,7 +89,7 @@ suite('getRestoreCacheCommand', () => {
             break;
           fi
         done;
-        restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" | awk '{print $1}'; fi )*/.cache" "/tmp/local-ci/v2-deps*/.cache")
+        restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null "package-lock.json" | awk '{print $1}'; fi )*/.cache" "/tmp/local-ci/v2-deps*/.cache")
         for directory_candidate in $restore_from_directories
           do
           if [ $(ls -ard $directory_candidate 2>/dev/null) ]

--- a/src/test/suite/utils/getRestoreCacheCommand.test.ts
+++ b/src/test/suite/utils/getRestoreCacheCommand.test.ts
@@ -31,7 +31,7 @@ suite('getRestoreCacheCommand', () => {
         )
       ),
       normalize(
-        `restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null "package-lock.json" || sha256sum "package-lock.json" 2>/dev/null | awk '{print $1}'; fi )*/.npm")
+        `restore_from_directories=("/tmp/local-ci/v2-deps-$( if [ -f "package-lock.json" ]; then shasum "package-lock.json" 2>/dev/null || sha256sum "package-lock.json" 2>/dev/null | awk '{print $1}'; fi )*/.npm")
         for directory_candidate in $restore_from_directories
           do
           if [ $(ls -ard $directory_candidate 2>/dev/null) ]

--- a/src/utils/convertToBash.ts
+++ b/src/utils/convertToBash.ts
@@ -20,7 +20,7 @@ export default function convertToBash(command: string): string {
             .replace(
               /checksum (\S+)/g,
               (fullMatch: string, fileName: string) =>
-                `if [ -f ${fileName} ]; then shasum ${fileName} 2> /dev/null || sha256sum ${fileName} 2> /dev/null | awk '{print $1}'; fi`
+                `if [ -f ${fileName} ]; then shasum ${fileName} 2>/dev/null || sha256sum ${fileName} 2>/dev/null | awk '{print $1}'; fi`
             )
             .replace(
               /\.Environment\.(\S+)/,

--- a/src/utils/convertToBash.ts
+++ b/src/utils/convertToBash.ts
@@ -20,7 +20,7 @@ export default function convertToBash(command: string): string {
             .replace(
               /checksum (\S+)/g,
               (fullMatch: string, fileName: string) =>
-                `if [ -f ${fileName} ]; then shasum ${fileName} | awk '{print $1}'; fi`
+                `if [ -f ${fileName} ]; then shasum ${fileName} 2> /dev/null || sha256sum ${fileName} 2> /dev/null | awk '{print $1}'; fi`
             )
             .replace(
               /\.Environment\.(\S+)/,

--- a/src/utils/convertToBash.ts
+++ b/src/utils/convertToBash.ts
@@ -20,7 +20,7 @@ export default function convertToBash(command: string): string {
             .replace(
               /checksum (\S+)/g,
               (fullMatch: string, fileName: string) =>
-                `if [ -f ${fileName} ]; then shasum ${fileName} 2>/dev/null || sha256sum ${fileName} 2>/dev/null | awk '{print $1}'; fi`
+                `if [ -f ${fileName} ]; then shasum ${fileName} 2>/dev/null ${fileName} || sha256sum ${fileName} 2>/dev/null | awk '{print $1}'; fi`
             )
             .replace(
               /\.Environment\.(\S+)/,

--- a/src/utils/convertToBash.ts
+++ b/src/utils/convertToBash.ts
@@ -20,7 +20,7 @@ export default function convertToBash(command: string): string {
             .replace(
               /checksum (\S+)/g,
               (fullMatch: string, fileName: string) =>
-                `if [ -f ${fileName} ]; then shasum ${fileName} 2>/dev/null ${fileName} || sha256sum ${fileName} 2>/dev/null | awk '{print $1}'; fi`
+                `if [ -f ${fileName} ]; then shasum ${fileName} 2>/dev/null || sha256sum ${fileName} 2>/dev/null | awk '{print $1}'; fi`
             )
             .replace(
               /\.Environment\.(\S+)/,

--- a/src/utils/getSaveCacheCommand.ts
+++ b/src/utils/getSaveCacheCommand.ts
@@ -22,6 +22,7 @@ export default function getSaveCacheCommand(
       then
       echo "${directory} does not exist, skipping caching"
     else
+      echo "Saving ${directory} to the cache"
       mkdir -p ${destination}
       cp -rn ${directory} ${destinationWhenCopied} || cp -ru ${directory} ${destinationWhenCopied}
     fi \n`;

--- a/src/utils/getSaveCacheCommand.ts
+++ b/src/utils/getSaveCacheCommand.ts
@@ -22,7 +22,6 @@ export default function getSaveCacheCommand(
       then
       echo "${directory} does not exist, skipping caching"
     else
-      echo "Saving ${directory} to the cache"
       mkdir -p ${destination}
       cp -rn ${directory} ${destinationWhenCopied} || cp -ru ${directory} ${destinationWhenCopied}
     fi \n`;


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Use sha256sum if shasum doesn't produce anything
* Some containers don't have `shasum`, apparently. And it caused the job to fail, in spite of the `2>/dev/null`


