### PR TITLE
Change the minimum VS Code version to `1.60.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/mocha": "^9.1.0",
         "@types/node": "^17.0.23",
         "@types/sinon": "^10.0.11",
-        "@types/vscode": "^1.70.0",
+        "@types/vscode": "^1.60.0",
         "@typescript-eslint/eslint-plugin": "^5.17.0",
         "@typescript-eslint/parser": "^5.17.0",
         "@vscode/test-electron": "^2.1.5",
@@ -48,7 +48,7 @@
       },
       "engines": {
         "node": "16",
-        "vscode": "^1.70.0"
+        "vscode": "^1.60.0"
       }
     },
     "node_modules/@cloudflare/binary-install": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "qna": "https://github.com/getlocalci/local-ci/discussions",
   "engines": {
-    "vscode": "^1.70.0",
+    "vscode": "^1.60.0",
     "node": "16"
   },
   "os": [
@@ -282,7 +282,7 @@
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.23",
     "@types/sinon": "^10.0.11",
-    "@types/vscode": "^1.70.0",
+    "@types/vscode": "^1.60.0",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
     "@vscode/test-electron": "^2.1.5",


### PR DESCRIPTION
* Change the minimum VS Code version back to 1.60.0
* This came out [a year ago](https://code.visualstudio.com/updates/v1_60)

<!--- Please summarize this PR in the title above -->
