### PR TITLE
Add basic support for Doppler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "local-ci",
-  "version": "1.7.9",
+  "version": "1.8.0-alpha1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "local-ci",
-      "version": "1.7.9",
+      "version": "1.8.0-alpha1",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "os": [

--- a/package.json
+++ b/package.json
@@ -54,6 +54,16 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "configuration": {
+      "title": "Local CI Environment Variables",
+      "properties": {
+        "localCi.environmentVariable.manager": {
+          "type": "string",
+          "defaul": "",
+          "description": "The environemnt variable manager to use, if any"
+        }
+      }
+    },
     "commands": [
       {
         "command": "local-ci.job.run",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "local-ci",
   "displayName": "Local CI",
   "description": "Debug CircleCI® workflows locally, with Bash access during and after. Free preview, then paid.",
-  "version": "1.7.9",
+  "version": "1.8.0-alpha1",
   "publisher": "LocalCI",
   "contributors": [
     "Ryan Kienstra"
@@ -57,7 +57,7 @@
     "configuration": {
       "title": "Local CI Environment Variables",
       "properties": {
-        "localCi.environmentVariable.manager": {
+        "localCi.environmentVariables.manager": {
           "type": "string",
           "defaul": "",
           "description": "The environemnt variable manager to use, if any"

--- a/src/utils/runJob.ts
+++ b/src/utils/runJob.ts
@@ -110,13 +110,16 @@ export default async function runJob(
     vscode.workspace
       .getConfiguration('localCi')
       .get('environmentVariable.manager');
-  terminal.sendText(`if [ ! "$(doppler --version 2>/dev/null)" ]
-    then
-      echo
-      echo "doppler is not installed, but it's enabled in settings.json in the property localCi.environmentVariable.manager"
-      echo "Please either install it, or remove that from settings.json"
-    fi
-  `);
+
+  if (isDopplerEnabled) {
+    terminal.sendText(`if [ ! "$(doppler --version 2>/dev/null)" ]
+      then
+        echo
+        echo "doppler is not installed, but it's enabled in settings.json in the property localCi.environmentVariable.manager"
+        echo "Please either install it, or remove that from settings.json"
+      fi
+    `);
+  }
   const dopplerCommand = isDopplerEnabled ? 'doppler run --' : '';
 
   terminal.sendText(

--- a/src/utils/runJob.ts
+++ b/src/utils/runJob.ts
@@ -112,7 +112,7 @@ export default async function runJob(
     'doppler' ===
     vscode.workspace
       .getConfiguration('localCi')
-      .get('environmentVariable.manager')
+      .get('environmentVariables.manager')
       ? 'doppler run --'
       : '';
 

--- a/src/utils/validateSettings.ts
+++ b/src/utils/validateSettings.ts
@@ -1,0 +1,30 @@
+import * as cp from 'child_process';
+import * as vscode from 'vscode';
+import getSpawnOptions from './getSpawnOptions';
+
+/**
+ * Shows a warning the configuration is wrong.
+ */
+export default function validateSettings(): void {
+  if (
+    'doppler' !==
+    vscode.workspace
+      .getConfiguration('localCi')
+      .get('environmentVariable.manager')
+  ) {
+    return;
+  }
+
+  try {
+    cp.execSync('doppler --version', {
+      ...getSpawnOptions(),
+      timeout: 2000,
+    });
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      `doppler is not installed on your machine, but it's enabled in settings.json via the property localCi.environmentVariable.manager.
+      Please either install it, or remove that value from settings.json.`,
+      { detail: 'Settings error' }
+    );
+  }
+}

--- a/src/utils/validateSettings.ts
+++ b/src/utils/validateSettings.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import getSpawnOptions from './getSpawnOptions';
 
 /**
- * Shows a warning the configuration is wrong.
+ * Validates settings.json, and shows an error message if it's invalid.
  */
 export default function validateSettings(): void {
   if (
@@ -22,7 +22,7 @@ export default function validateSettings(): void {
     });
   } catch (error) {
     vscode.window.showErrorMessage(
-      `doppler is not installed on your machine, but it's enabled in settings.json via the property localCi.environmentVariable.manager.
+      `Error: doppler is not installed on your machine, but it's enabled in settings.json via the property localCi.environmentVariable.manager.
       Please either install it, or remove that value from settings.json.`,
       { detail: 'Settings error' }
     );

--- a/src/utils/validateSettings.ts
+++ b/src/utils/validateSettings.ts
@@ -10,7 +10,7 @@ export default function validateSettings(): void {
     'doppler' !==
     vscode.workspace
       .getConfiguration('localCi')
-      .get('environmentVariable.manager')
+      .get('environmentVariables.manager')
   ) {
     return;
   }
@@ -22,7 +22,7 @@ export default function validateSettings(): void {
     });
   } catch (error) {
     vscode.window.showErrorMessage(
-      `Error: doppler is not installed on your machine, but it's enabled in settings.json via the property localCi.environmentVariable.manager.
+      `Error: doppler is not installed on your machine, but it's enabled in settings.json via the property localCi.environmentVariables.manager.
       Please either install it, or remove that value from settings.json.`,
       { detail: 'Settings error' }
     );


### PR DESCRIPTION
Enables running `doppler` when this is in the VS Code `settings.json`:

```json
"localCi.environmentVariables.manager": "doppler"
```

It will run this command:

```sh

doppler run -- /Users/rk/Projects/ci/local-ci/bin/circleci/Da
rwin/x64/bin/circleci local execute --job 'php-test-7.3' --config /tmp/local-ci
/circleci-tutorial-for-beginners/process.yml -v /tmp/local-ci/circleci-tutorial
-for-beginners/volume:/tmp/local-ci
```

If `doppler` isn't installed and that is in `settings.json`, this shows an error:

![Screen Shot 2022-08-23 at 11 14 33 PM](https://user-images.githubusercontent.com/4063887/186327750-b5dbcd1a-d051-4aa4-af3a-fe62a1918050.png)

Closes https://github.com/getlocalci/local-ci/discussions/172
