### PR TITLE
Fix an issue on Intel Mac, where it fails from the wrong build agent

### DIFF
--- a/src/test/suite/utils/areTerminalsClosed.test.ts
+++ b/src/test/suite/utils/areTerminalsClosed.test.ts
@@ -20,7 +20,7 @@ const baseTerminal = {
 };
 
 suite('areTerminalsClosed', () => {
-  test('Only one is closed', () => {
+  test('only one is closed', () => {
     assert.strictEqual(
       false,
       areTerminalsClosed(
@@ -30,7 +30,7 @@ suite('areTerminalsClosed', () => {
     );
   });
 
-  test('All are closed', () => {
+  test('all are closed', () => {
     assert.strictEqual(
       true,
       areTerminalsClosed(
@@ -40,7 +40,7 @@ suite('areTerminalsClosed', () => {
     );
   });
 
-  test('One undefined, one closed', () => {
+  test('one undefined, one closed', () => {
     assert.strictEqual(
       true,
       areTerminalsClosed(

--- a/src/test/suite/utils/cleanUpCommittedImages.test.ts
+++ b/src/test/suite/utils/cleanUpCommittedImages.test.ts
@@ -8,7 +8,7 @@ mocha.afterEach(() => {
 });
 
 suite('cleanUpCommittedImages', () => {
-  test('No error', () => {
+  test('no error', () => {
     sinon.mock(cp).expects('spawnSync').twice();
     cleanUpCommittedImages('local-ci-lint');
   });

--- a/src/test/suite/utils/disposeTerminalsForJob.test.ts
+++ b/src/test/suite/utils/disposeTerminalsForJob.test.ts
@@ -8,7 +8,7 @@ mocha.afterEach(() => {
 });
 
 suite('disposeTerminalsForJob', () => {
-  test('Terminal is not disposed', async () => {
+  test('terminal is not disposed', async () => {
     const jobName = 'build';
 
     sinon.stub(vscode, 'window').value({
@@ -23,7 +23,7 @@ suite('disposeTerminalsForJob', () => {
     disposeTerminalsForJob(jobName);
   });
 
-  test('Terminal is disposed', async () => {
+  test('terminal is disposed', async () => {
     const jobName = 'build';
 
     sinon.stub(vscode, 'window').value({

--- a/src/test/suite/utils/getAllJobs.test.ts
+++ b/src/test/suite/utils/getAllJobs.test.ts
@@ -5,7 +5,7 @@ import getAllJobs from '../../../utils/getJobs';
 import { getTestFilePath } from '../../helpers';
 
 suite('getAllJobs', () => {
-  test('Jobs from fixture', () => {
+  test('jobs from fixture', () => {
     assert.strictEqual(
       getAllJobs(
         getConfig(

--- a/src/test/suite/utils/getAttachWorkspaceCommand.test.ts
+++ b/src/test/suite/utils/getAttachWorkspaceCommand.test.ts
@@ -3,11 +3,11 @@ import { normalize } from '../../helpers';
 import getAttachWorkspaceCommand from '../../../utils/getAttachWorkspaceCommand';
 
 suite('getAttachWorkspaceCommand', () => {
-  test('No attach_workspace', () => {
+  test('no attach_workspace', () => {
     assert.strictEqual(getAttachWorkspaceCommand({}), '');
   });
 
-  test('With attach_workspace', () => {
+  test('with attach_workspace', () => {
     assert.strictEqual(
       normalize(
         getAttachWorkspaceCommand({ attach_workspace: { at: '/foo/baz' } })

--- a/src/test/suite/utils/getCheckoutJobs.test.ts
+++ b/src/test/suite/utils/getCheckoutJobs.test.ts
@@ -9,11 +9,11 @@ mocha.afterEach(() => {
 });
 
 suite('getCheckoutJobs', () => {
-  test('No config file', () => {
+  test('no config file', () => {
     assert.deepStrictEqual(getCheckoutJobs(undefined), []);
   });
 
-  test('No checkout job', () => {
+  test('no checkout job', () => {
     sinon.mock(fs).expects('existsSync').once().returns(true);
     sinon.mock(fs).expects('readFileSync').once().returns('');
 

--- a/src/test/suite/utils/getConfig.test.ts
+++ b/src/test/suite/utils/getConfig.test.ts
@@ -10,13 +10,13 @@ mocha.afterEach(() => {
 });
 
 suite('getConfig', () => {
-  test('No config', () => {
+  test('no config', () => {
     sinon.mock(fs).expects('existsSync').once().returns(false);
     sinon.mock(fs).expects('readFileSync').never();
     assert.strictEqual(getConfig(''), undefined);
   });
 
-  test('With config', () => {
+  test('with config', () => {
     const configFile = {
       jobs: { test: { docker: [{ image: 'cimg/node:16.8.0-browsers' }] } },
     };

--- a/src/test/suite/utils/getDockerError.test.ts
+++ b/src/test/suite/utils/getDockerError.test.ts
@@ -9,12 +9,12 @@ mocha.afterEach(() => {
 });
 
 suite('getDockerError', () => {
-  test('No error', () => {
+  test('no error', () => {
     sinon.mock(cp).expects('execSync').once();
     assert.strictEqual(getDockerError(), '');
   });
 
-  test('With error', () => {
+  test('with error', () => {
     const message = 'Cannot connect to the Docker daemon';
     sinon.mock(cp).expects('execSync').once().throws({ message });
 

--- a/src/test/suite/utils/getDynamicConfigFilePath.test.ts
+++ b/src/test/suite/utils/getDynamicConfigFilePath.test.ts
@@ -2,14 +2,14 @@ import * as assert from 'assert';
 import getDynamicConfigPath from '../../../utils/getDynamicConfigPath';
 
 suite('getDynamicConfigFilePath', () => {
-  test('With empty string argument', () => {
+  test('with empty string argument', () => {
     assert.strictEqual(
       getDynamicConfigPath(''),
       '/tmp/local-ci/unknown/volume/dynamic-config.yml'
     );
   });
 
-  test('With path as argument', () => {
+  test('with path as argument', () => {
     assert.strictEqual(
       getDynamicConfigPath('/home/foo/baz/.circleci/config.yml'),
       '/tmp/local-ci/baz/volume/dynamic-config.yml'

--- a/src/test/suite/utils/getFirstWorkspaceRootPath.test.ts
+++ b/src/test/suite/utils/getFirstWorkspaceRootPath.test.ts
@@ -9,12 +9,12 @@ mocha.afterEach(() => {
 });
 
 suite('getFirstWorkspaceRootPath', () => {
-  test('With no workspaceFolders', () => {
+  test('with no workspaceFolders', () => {
     sinon.stub(vscode, 'workspace').value({});
     assert.strictEqual(getFirstWorkspaceRootPath(), '');
   });
 
-  test('With workspaceFolders', () => {
+  test('Wwith workspaceFolders', () => {
     const path = 'example';
     sinon.stub(vscode, 'workspace').value({
       workspaceFolders: [

--- a/src/test/suite/utils/getImageFromJob.test.ts
+++ b/src/test/suite/utils/getImageFromJob.test.ts
@@ -2,18 +2,18 @@ import * as assert from 'assert';
 import getImageFromJob from '../../../utils/getImageFromJob';
 
 suite('getImageFromJob', () => {
-  test('No docker value', () => {
+  test('no docker value', () => {
     assert.deepStrictEqual(
       getImageFromJob({ working_directory: 'foo/baz' }),
       ''
     );
   });
 
-  test('Empty docker array', () => {
+  test('empty docker array', () => {
     assert.deepStrictEqual(getImageFromJob({ docker: [] }), '');
   });
 
-  test('With docker image', () => {
+  test('with docker image', () => {
     assert.deepStrictEqual(
       getImageFromJob({ docker: [{ image: 'foo-image' }] }),
       'foo-image'

--- a/src/test/suite/utils/getJobs.test.ts
+++ b/src/test/suite/utils/getJobs.test.ts
@@ -5,7 +5,7 @@ import getJobs from '../../../utils/getJobs';
 import { getTestFilePath } from '../../helpers';
 
 suite('getJobs', () => {
-  test('Single job', () => {
+  test('single job', () => {
     assert.strictEqual(
       getJobs({
         jobs: {},
@@ -19,7 +19,7 @@ suite('getJobs', () => {
     );
   });
 
-  test('Multiple jobs', () => {
+  test('multiple jobs', () => {
     assert.strictEqual(
       getJobs({
         jobs: { lint: {}, test: {}, deploy: {} },
@@ -39,7 +39,7 @@ suite('getJobs', () => {
     );
   });
 
-  test('Multiple jobs from fixture', () => {
+  test('multiple jobs from fixture', () => {
     assert.strictEqual(
       getJobs(
         getConfig(

--- a/src/test/suite/utils/getLogFilePath.test.ts
+++ b/src/test/suite/utils/getLogFilePath.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import getLogFilePath from '../../../utils/getLogFilePath';
 
 suite('getLogFilePath', () => {
-  test('Empty path to config file', () => {
+  test('empty path to config file', () => {
     assert.ok(
       getLogFilePath('', 'test-lint').startsWith(
         '/tmp/local-ci/logs/test-lint/'
@@ -10,7 +10,7 @@ suite('getLogFilePath', () => {
     );
   });
 
-  test('With path to config file', () => {
+  test('with path to config file', () => {
     assert.ok(
       getLogFilePath('your-repo/.circleci/config.yml', 'test-lint').startsWith(
         '/tmp/local-ci/your-repo/logs/test-lint/'

--- a/src/test/suite/utils/getLogFilesDirectory.test.ts
+++ b/src/test/suite/utils/getLogFilesDirectory.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import getLogFilesDirectory from '../../../utils/getLogFilesDirectory';
 
 suite('getLogFilePath', () => {
-  test('With path to config file', () => {
+  test('with path to config file', () => {
     assert.strictEqual(
       getLogFilesDirectory('baz-repo/.circleci/config.yml', 'test-lint'),
       '/tmp/local-ci/baz-repo/logs/test-lint'

--- a/src/test/suite/utils/getPath.test.ts
+++ b/src/test/suite/utils/getPath.test.ts
@@ -9,19 +9,19 @@ mocha.afterEach(() => {
 });
 
 suite('getPath', () => {
-  test('On Linux', () => {
+  test('on Linux', () => {
     sinon.mock(os).expects('type').once().returns('Linux');
     sinon.stub(process, 'env').value({ PATH: '' });
     assert.strictEqual(getPath(), '');
   });
 
-  test('On Mac without the bin path', () => {
+  test('on Mac without the bin path', () => {
     sinon.mock(os).expects('type').once().returns('Darwin');
     sinon.stub(process, 'env').value({ PATH: 'Users/Foo/' });
     assert.strictEqual(getPath(), 'Users/Foo/:/usr/local/bin');
   });
 
-  test('On Mac with the bin path', () => {
+  test('on Mac with the bin path', () => {
     sinon.mock(os).expects('type').once().returns('Darwin');
     sinon.stub(process, 'env').value({ PATH: 'Users/Foo/:/usr/local/bin' });
     assert.strictEqual(getPath(), 'Users/Foo/:/usr/local/bin');

--- a/src/test/suite/utils/getSaveCacheSteps.test.ts
+++ b/src/test/suite/utils/getSaveCacheSteps.test.ts
@@ -4,7 +4,7 @@ import getConfigFromPath from '../../../utils/getConfigFromPath';
 import getSaveCacheSteps from '../../../utils/getSaveCacheSteps';
 
 suite('getSaveCacheSteps', () => {
-  test('With 2 save_cache values', () => {
+  test('with 2 save_cache values', () => {
     assert.deepStrictEqual(
       getSaveCacheSteps(
         getConfigFromPath(getTestFilePath('fixture', 'with-cache.yml'))

--- a/src/test/suite/utils/getSpawnOptions.test.ts
+++ b/src/test/suite/utils/getSpawnOptions.test.ts
@@ -10,7 +10,7 @@ mocha.afterEach(() => {
 });
 
 suite('getSpawnOptions', () => {
-  test('Has working directory', () => {
+  test('has working directory', () => {
     sinon.mock(os).expects('platform').once().returns('darwin');
     const path = 'example';
     sinon.stub(vscode, 'workspace').value({
@@ -23,12 +23,12 @@ suite('getSpawnOptions', () => {
     assert.strictEqual(getSpawnOptions().cwd, path);
   });
 
-  test('Has bin directory', () => {
+  test('has bin directory', () => {
     sinon.mock(os).expects('platform').once().returns('darwin');
     assert.ok(getSpawnOptions().env.PATH.includes('/usr/local/bin'));
   });
 
-  test('With cwd argument', () => {
+  test('with cwd argument', () => {
     assert.strictEqual(getSpawnOptions('/foo/baz').cwd, '/foo/baz');
   });
 });

--- a/src/test/suite/utils/isDockerRunning.test.ts
+++ b/src/test/suite/utils/isDockerRunning.test.ts
@@ -9,7 +9,7 @@ mocha.afterEach(() => {
 });
 
 suite('isDockerRunning', () => {
-  test('Is not running', () => {
+  test('is not running', () => {
     sinon
       .mock(cp)
       .expects('execSync')
@@ -18,7 +18,7 @@ suite('isDockerRunning', () => {
     assert.strictEqual(isDockerRunning(), false);
   });
 
-  test('Is running', () => {
+  test('is running', () => {
     sinon.mock(cp).expects('execSync').once();
     assert.strictEqual(isDockerRunning(), true);
   });

--- a/src/test/suite/utils/sanitizeLicenseKey.test.ts
+++ b/src/test/suite/utils/sanitizeLicenseKey.test.ts
@@ -2,39 +2,39 @@ import * as assert from 'assert';
 import sanitizeLicenseKey from '../../../utils/sanitizeLicenseKey';
 
 suite('sanitizeLicenseKey', () => {
-  test('Empty', async () => {
+  test('empty', async () => {
     assert.strictEqual(sanitizeLicenseKey(''), '');
   });
 
-  test('Only letters and numbers', () => {
+  test('only letters and numbers', () => {
     assert.strictEqual(
       sanitizeLicenseKey('1b2e78c9b0ea4ee888fed8a66d553dfc'),
       '1b2e78c9b0ea4ee888fed8a66d553dfc'
     );
   });
 
-  test('With dashes', () => {
+  test('with dashes', () => {
     assert.strictEqual(
       sanitizeLicenseKey('e9bd961ce2d04c0ab2f5b3212127b01a'),
       'e9bd961ce2d04c0ab2f5b3212127b01a'
     );
   });
 
-  test('With tag', () => {
+  test('with tag', () => {
     assert.strictEqual(
       sanitizeLicenseKey('ccae17<script>alert("dothis")</script>632f10407'),
       'ccae17scriptalertdothisscript632f10407'
     );
   });
 
-  test('With invalid characters', () => {
+  test('with invalid characters', () => {
     assert.strictEqual(
       sanitizeLicenseKey('66e56321$(*&@!2b0b4~**))5b1af385e10ff9049e8'),
       '66e563212b0b45b1af385e10ff9049e8'
     );
   });
 
-  test('With whitespace', () => {
+  test('with whitespace', () => {
     assert.strictEqual(
       sanitizeLicenseKey(' f5d5e 32c017b4e9 8a066d8c22e6f1ea1 '),
       'f5d5e32c017b4e98a066d8c22e6f1ea1'

--- a/src/test/suite/utils/setBuildAgentSettings.test.ts
+++ b/src/test/suite/utils/setBuildAgentSettings.test.ts
@@ -10,7 +10,7 @@ mocha.afterEach(() => {
 });
 
 suite('setBuildAgentSettings', () => {
-  test('should set the settings on a Linux machine', () => {
+  test('should not set the settings on a Linux machine', () => {
     const spawnSpy = sinon.spy();
     sinon.stub(os, 'type').value(() => 'Intel');
     sinon.stub(os, 'arch').value(() => 'x64');
@@ -20,9 +20,19 @@ suite('setBuildAgentSettings', () => {
     assert.equal(spawnSpy.called, false);
   });
 
+  test('should not set the settings on an M1 Mac machine', () => {
+    const spawnSpy = sinon.spy();
+    sinon.stub(os, 'type').value(() => 'Darwin');
+    sinon.stub(os, 'arch').value(() => 'arm64');
+    sinon.stub(cp, 'spawn').value(spawnSpy);
+
+    setBuildAgentSettings();
+    assert.equal(spawnSpy.called, false);
+  });
+
   test('should set the settings on an Intel Mac machine', () => {
     const spawnSpy = sinon.spy();
-    sinon.stub(os, 'type').value(() => 'Intel');
+    sinon.stub(os, 'type').value(() => 'Darwin');
     sinon.stub(os, 'arch').value(() => 'x64');
     sinon.stub(cp, 'spawn').value(spawnSpy);
 

--- a/src/test/suite/utils/setBuildAgentSettings.test.ts
+++ b/src/test/suite/utils/setBuildAgentSettings.test.ts
@@ -1,0 +1,32 @@
+import * as assert from 'assert';
+import * as cp from 'child_process';
+import * as mocha from 'mocha';
+import * as os from 'os';
+import * as sinon from 'sinon';
+import setBuildAgentSettings from '../../../utils/setBuildAgentSettings';
+
+mocha.afterEach(() => {
+  sinon.restore();
+});
+
+suite('setBuildAgentSettings', () => {
+  test('should set the settings on a Linux machine', () => {
+    const spawnSpy = sinon.spy();
+    sinon.stub(os, 'type').value(() => 'Intel');
+    sinon.stub(os, 'arch').value(() => 'x64');
+    sinon.stub(cp, 'spawn').value(spawnSpy);
+
+    setBuildAgentSettings();
+    assert.equal(spawnSpy.called, false);
+  });
+
+  test('should set the settings on an Intel Mac machine', () => {
+    const spawnSpy = sinon.spy();
+    sinon.stub(os, 'type').value(() => 'Intel');
+    sinon.stub(os, 'arch').value(() => 'x64');
+    sinon.stub(cp, 'spawn').value(spawnSpy);
+
+    setBuildAgentSettings();
+    assert.equal(spawnSpy.called, true);
+  });
+});

--- a/src/test/suite/utils/showFinalTerminalHelperMessages.test.ts
+++ b/src/test/suite/utils/showFinalTerminalHelperMessages.test.ts
@@ -10,7 +10,7 @@ mocha.afterEach(() => {
 });
 
 suite('showFinalTerminalHelperMessages', () => {
-  test('No helper message', async () => {
+  test('no helper message', async () => {
     const showInformationMessageSpy = sinon.spy();
     sinon.stub(vscode, 'window').value({
       showInformationMessage: showInformationMessageSpy,
@@ -31,7 +31,7 @@ suite('showFinalTerminalHelperMessages', () => {
     assert.strictEqual(showInformationMessageSpy.called, false);
   });
 
-  test('With helper message', async () => {
+  test('with helper message', async () => {
     const showInformationMessageSpy = sinon.spy();
     sinon.stub(vscode, 'window').value({
       showInformationMessage: showInformationMessageSpy,

--- a/src/test/suite/utils/uncommittedWarning.test.ts
+++ b/src/test/suite/utils/uncommittedWarning.test.ts
@@ -24,7 +24,7 @@ function getMockContext(isSuppressed: boolean) {
 }
 
 suite('uncommittedWarning', () => {
-  test('Warning is suppressed', async () => {
+  test('warning is suppressed', async () => {
     const showWarningMessageSpy = Promise.resolve(sinon.spy());
     sinon.stub(vscode, 'window').value({
       showWarningMessage: showWarningMessageSpy,
@@ -34,7 +34,7 @@ suite('uncommittedWarning', () => {
     assert.strictEqual((await showWarningMessageSpy).called, false);
   });
 
-  test('No uncommitted file', async () => {
+  test('no uncommitted file', async () => {
     const showWarningMessageSpy = sinon.spy();
     sinon.stub(vscode, 'window').value({
       showWarningMessage: async (message: string) =>
@@ -56,7 +56,7 @@ suite('uncommittedWarning', () => {
     assert.strictEqual(showWarningMessageSpy.called, false);
   });
 
-  test('Only an uncommitted config file should not show a warning', async () => {
+  test('only an uncommitted config file should not show a warning', async () => {
     const showWarningMessageSpy = sinon.spy();
     sinon.stub(vscode, 'window').value({
       showWarningMessage: async (message: string) =>
@@ -78,7 +78,7 @@ suite('uncommittedWarning', () => {
     assert.strictEqual(showWarningMessageSpy.called, false);
   });
 
-  test('With uncommitted files', async () => {
+  test('with uncommitted files', async () => {
     const showWarningMessageSpy = sinon.spy();
     sinon.stub(vscode, 'window').value({
       showWarningMessage: async (message: string) =>
@@ -100,7 +100,7 @@ suite('uncommittedWarning', () => {
     assert.ok(showWarningMessageSpy.called);
   });
 
-  test('Not a checkout job', async () => {
+  test('not a checkout job', async () => {
     const showWarningMessageSpy = sinon.spy();
     sinon.stub(vscode, 'window').value({
       showWarningMessage: async (message: string) =>

--- a/src/test/suite/utils/writeProcessFile.test.ts
+++ b/src/test/suite/utils/writeProcessFile.test.ts
@@ -10,12 +10,12 @@ mocha.afterEach(() => {
 });
 
 suite('writeProcessFile', () => {
-  test('No config', () => {
+  test('no config', () => {
     sinon.mock(fs).expects('writeFileSync').once().withArgs({});
     writeProcessFile('', '/foo/baz');
   });
 
-  test('Full config file with cache', () => {
+  test('full config file with cache', () => {
     const fileName = 'with-cache.yml';
     sinon.mock(fs).expects('mkdirSync').once();
 
@@ -35,7 +35,7 @@ suite('writeProcessFile', () => {
     );
   });
 
-  test('Dynamic config', () => {
+  test('dynamic config', () => {
     const fileName = 'dynamic-config.yml';
     sinon.mock(fs).expects('mkdirSync').once();
 

--- a/src/utils/runJob.ts
+++ b/src/utils/runJob.ts
@@ -17,6 +17,7 @@ import getLocalVolumePath from './getLocalVolumePath';
 import getProcessFilePath from './getProcessFilePath';
 import getTerminalName from './getTerminalName';
 import listenToJob from './listenToJob';
+import setBuildAgentSettings from './setBuildAgentSettings';
 import showFinalTerminalHelperMessages from './showFinalTerminalHelperMessages';
 import JobClass from '../classes/Job';
 import {
@@ -88,6 +89,7 @@ export default async function runJob(
   }
 
   uncommittedWarning(context, repoPath, jobName, checkoutJobs);
+  setBuildAgentSettings();
 
   // If this is the only checkout job, it's probably at the beginning of the workflow.
   // So delete the local volume directory to give a clean start to the workflow,

--- a/src/utils/setBuildAgentSettings.ts
+++ b/src/utils/setBuildAgentSettings.ts
@@ -1,0 +1,28 @@
+import * as cp from 'child_process';
+import { type, arch } from 'os';
+import getSpawnOptions from './getSpawnOptions';
+
+function isIntelMac() {
+  return type() === 'Darwin' && arch() === 'x64';
+}
+
+export default function setBuildAgentSettings() {
+  if (!isIntelMac()) {
+    return;
+  }
+
+  cp.spawn(
+    '/bin/sh',
+    [
+      '-c',
+      `settings_file=~/.circleci/build_agent_settings.json
+      rm $settings_file 2>/dev/null
+      mkdir -p ~/.circleci
+      echo '{"LatestSha256":"sha256:008ba7f4223f1e26c11df9575283491b620074fa96da6961e0dcde47fb757014"}' > $settings_file`,
+    ],
+    {
+      ...getSpawnOptions(),
+      timeout: 5000,
+    }
+  );
+}


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

* Though the latest version of the [binary](https://github.com/circleci-public/circleci-cli) doesn't write a `build_agent_settings.json`, that binary doesn't work on Intel Mac.
* So this write that `.json` file with the agent version that will work on an Intel Mac.
* This should mean that Local CI works right away on Intel Macs.


