### PR TITLE
Add a button to complain to me

### DIFF
--- a/src/job/JobListener.ts
+++ b/src/job/JobListener.ts
@@ -51,6 +51,8 @@ export default class JobListener {
       logFilePath,
       `Log for CircleCI® job ${jobName} \n${new Date()} \n\n`
     );
+    const complainToMeLink =
+      'mailto:ryan@getlocalci.com?subject=There was an error using Local CI&body=Hi Ryan, Could you help with this error I saw with Local CI: <!-- please fill in error here -->';
 
     const process = this.childProcessGateway.cp.spawn(
       '/bin/sh',
@@ -124,10 +126,19 @@ export default class JobListener {
 
       dockerRelatedErrors.forEach((errorMessage) => {
         if (output?.includes(errorMessage)) {
-          this.editorGateway.editor.window.showErrorMessage(
-            `Restarting Docker Desktop should fix that error '${errorMessage}', though that's not fun`,
-            { detail: 'Possible solution' }
-          );
+          const complainToMeText = 'Complain to me';
+          this.editorGateway.editor.window
+            .showErrorMessage(
+              `Restarting Docker Desktop should fix that error '${errorMessage}', though that's not fun`,
+              { detail: 'Possible solution' }
+            )
+            .then((clicked) => {
+              if (clicked === complainToMeText) {
+                this.editorGateway.editor.env.openExternal(
+                  this.editorGateway.editor.Uri.parse(complainToMeLink)
+                );
+              }
+            });
         }
       });
 
@@ -152,16 +163,24 @@ export default class JobListener {
       errors.forEach((error) => {
         if (output?.includes(error.message)) {
           const getBashCommandsText = 'Get Bash commands';
+          const complainToMeText = 'Complain to me';
           this.editorGateway.editor.window
             .showErrorMessage(
               'You might be able to fix this failed job with Bash commands',
               { detail: 'Possible solution' },
-              getBashCommandsText
+              getBashCommandsText,
+              complainToMeText
             )
             .then((clicked) => {
               if (clicked === getBashCommandsText) {
                 this.editorGateway.editor.env.openExternal(
                   this.editorGateway.editor.Uri.parse(error.solutionUrl)
+                );
+              }
+
+              if (clicked === complainToMeText) {
+                this.editorGateway.editor.env.openExternal(
+                  this.editorGateway.editor.Uri.parse(complainToMeLink)
                 );
               }
             });

--- a/src/job/JobListener.ts
+++ b/src/job/JobListener.ts
@@ -130,7 +130,8 @@ export default class JobListener {
           this.editorGateway.editor.window
             .showErrorMessage(
               `Restarting Docker Desktop should fix that error '${errorMessage}', though that's not fun`,
-              { detail: 'Possible solution' }
+              { detail: 'Possible solution' },
+              complainToMeText
             )
             .then((clicked) => {
               if (clicked === complainToMeText) {

--- a/src/job/JobListener.ts
+++ b/src/job/JobListener.ts
@@ -208,12 +208,17 @@ export default class JobListener {
     }
 
     const showJobOutput = 'Show job log';
+    const complainToMeText = 'Complain to me';
+    const complainToMeLink =
+      'mailto:ryan@getlocalci.com?subject=A job failed with Local Ci, and I do not know why&body=Hi Ryan, Could you help with this error I saw with a Local CI job: <!-- please fill in error here -->';
     const dontShowAgain = `Don't show again`;
+
     this.editorGateway.editor.window
       .showInformationMessage(
         `The job ${job?.getJobName()} ${didSucceed ? 'succeeded' : 'failed'}`,
-        showJobOutput,
-        dontShowAgain
+        ...(didSucceed
+          ? [showJobOutput, dontShowAgain]
+          : [showJobOutput, complainToMeText, dontShowAgain])
       )
       .then((clicked) => {
         if (clicked === showJobOutput) {
@@ -222,6 +227,12 @@ export default class JobListener {
 
         if (clicked === dontShowAgain) {
           context.globalState.update(SUPPRESS_JOB_COMPLETE_MESSAGE, true);
+        }
+
+        if (clicked === complainToMeText) {
+          this.editorGateway.editor.env.openExternal(
+            this.editorGateway.editor.Uri.parse(complainToMeLink)
+          );
         }
       });
   }


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

## Changes
* Add buttons to complain to me when a job fails, or when there are detected errors
* Thanks to Jason Cohen's [advice](https://blog.asmartbear.com/more-sales-customer-feedback.html) on asking for feedback in a non-corporate way
* This only opens the users' email client. In the email, they can decide what to say about the error.

<img width="671" alt="Screen Shot 2022-09-20 at 7 28 58 PM" src="https://user-images.githubusercontent.com/4063887/191388227-4649ca3c-7b7e-4ea4-a4c4-bdcb120ca14e.png">

