### PR TITLE
Change to 'Please select repo', as that's what they should do

### DIFF
--- a/src/job/Children.ts
+++ b/src/job/Children.ts
@@ -149,7 +149,7 @@ export default class Children {
         ];
       case JobError.NoConfigFilePathSelected:
         return [
-          this.warningFactory.create('Error: No jobs found'),
+          this.warningFactory.create('Please select repo'),
           this.commandFactory.create('Select repo', 'localCiJobs.selectRepo'),
           this.commandFactory.create('Complain to me', COMPLAIN_COMMAND),
         ];


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Change 'No jobs found' to  'Please select repo'
* They shouldn't have to know about jobs, just that they need to select a repo: 
![Screen Shot 2022-10-14 at 7 20 26 PM](https://user-images.githubusercontent.com/4063887/195960393-ab208a92-d9df-4c37-847d-57bb1a94e0d6.png)

